### PR TITLE
Update flake.lock - 2025-08-08T22-32-57Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1259,11 +1259,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754681400,
-        "narHash": "sha256-sXKv+qJI9RLnvFKXOt8IWE1iGUBEz1scdJYlG+j+L0s=",
+        "lastModified": 1754689711,
+        "narHash": "sha256-GVb7+6D6QSavLyqcWrMMbe8RGUJ+htc1OZawL/LYFfg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77e5f5ba0fe9184f2056e6bf447e47e89cfc5940",
+        "rev": "72feb9594806cfe8a68b171d9f47e818a5999b5c",
         "type": "github"
       },
       "original": {
@@ -1800,11 +1800,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754666623,
-        "narHash": "sha256-h1tBGJKojafM/WvU2lz4wusR3sJHnbDItADQQUn7dAI=",
+        "lastModified": 1754691610,
+        "narHash": "sha256-prHJmEX7HU1uwjHyTFBqRxZllMLimNngTYM08SLVulY=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a997acaa5202a9f9c62a72a918a11427fa36615a",
+        "rev": "1dfc25866c405b025415a615aaba411f5641b2b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
🔄 Updating inputs (excluding {'lix', 'lix-module'}):
👉 Will update: ['chaotic', 'deploy-rs', 'disko', 'distro-grub-themes', 'flake-parts', 'home-manager', 'honkai-railway-grub-theme', 'hyprland', 'niri', 'nix-index-database', 'nixos-generators', 'nixpkgs', 'nixpkgs-stable', 'nur', 'nvf', 'quickshell', 'sops-nix', 'spicetify-nix', 'stylix', 'treefmt-nix', 'zen-browser']