### PR TITLE
Update flake.lock - 2026-04-16T18-56-21Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776273122,
-        "narHash": "sha256-bo8xUFqJaj1s7qbY86DPPcrvy1BGi9QOMrDcDk+N9/E=",
+        "lastModified": 1776360169,
+        "narHash": "sha256-E2WJUPP3HN55CWoqYXfJiML4EZdjYgrLwwNtkbBynlk=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "6e69222d5343f4edfc7aeb02e5c844e122269cfb",
+        "rev": "25d3cb91314c9481e96bc81ecbe5a51f14099027",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1776276904,
-        "narHash": "sha256-B1GCI52gcBFc4CwnglV0U574J/ADFWyqfHmhMQ7cgGk=",
+        "lastModified": 1776341172,
+        "narHash": "sha256-sUZ15JZ8flsBoSptFXqA0kshoAqry/xgpm/Nnn8/jTg=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "2fb28986f1dce78e4b09e29085559197f6d692fa",
+        "rev": "b85785c7a31f9c4d8e835908fb4ac45e5bcafe65",
         "type": "github"
       },
       "original": {
@@ -755,11 +755,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1776187484,
-        "narHash": "sha256-gpm/WZCBcvITN0pQbhVvlEIqqhma8OHKiO5NGpFygkc=",
+        "lastModified": 1776365273,
+        "narHash": "sha256-Tzjt/E5JNuo07CQ/PPiY5zh11PqWzd07A/3mSZvtm0Y=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "88f3e7e9d519ae704cab78548c6f6bf02a0b0841",
+        "rev": "b5ea887f072fa055cf23ec389ed81e3ee4c5319a",
         "type": "github"
       },
       "original": {
@@ -1008,11 +1008,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776243263,
-        "narHash": "sha256-5GN5o5NG9P08N+p4vn88ydvlsiyogClaBugtp4o7txw=",
+        "lastModified": 1776335039,
+        "narHash": "sha256-2lkQhrv6YUCeMlC/lclzq9vkTALv/ptv7d0jIhZnrPQ=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "c05685d0c40ce74a50181e7167bc7dde48d182d0",
+        "rev": "cbdf76c063b48d5d755fb26540367b8c2457c2ca",
         "type": "github"
       },
       "original": {
@@ -1160,11 +1160,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -1237,11 +1237,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1776278724,
-        "narHash": "sha256-Lh7n6NsHJpnKUMfMBoBtdbqAhoB4jYoM2P4IdKuBkU4=",
+        "lastModified": 1776365007,
+        "narHash": "sha256-oxWbbN+O8awO0fjHkq7IAE18yiN1ulqFHZ9yf4fp4xM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08135a06653a3a9c706d9766c2de2b58329a77ea",
+        "rev": "ca8c62a50e124cbc28bb118bdbd307be8186decd",
         "type": "github"
       },
       "original": {
@@ -1494,11 +1494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776278199,
-        "narHash": "sha256-qjIC9Cb3eFLETRhuX4WEcgdYM/EPQjIaYsqncf1VFvk=",
+        "lastModified": 1776365179,
+        "narHash": "sha256-sWjDIksXFWtCWqYlyF4mTvzeNBr9Y0jUHDwnI8/5eUA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71f712123a6b1322a22db7dcf7b8de3e4d35a557",
+        "rev": "f47fbd4325f66530ffd464bcdc3784e016513e38",
         "type": "github"
       },
       "original": {
@@ -1542,11 +1542,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1776275596,
-        "narHash": "sha256-AvYKYDCnor/4U3AkpPjXmTrHLpEndVJXJEEdrcioEs4=",
+        "lastModified": 1776331518,
+        "narHash": "sha256-Hj6Rqmyv7f2CkQN4f3NLnK0VUJM/ypfHIrkGckA4WQA=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "3b429e3d3da47e3adc89dd1fc64cdc2f99e31631",
+        "rev": "39416a521dbbc3b722de1bb3607cddaa1e698f4a",
         "type": "github"
       },
       "original": {
@@ -1600,11 +1600,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775720097,
-        "narHash": "sha256-p+vqkCuFfVNyQBo370wr6MebNUvz55RZiC0m8YKUhvQ=",
+        "lastModified": 1776066068,
+        "narHash": "sha256-SwKVkgEsqsp5ki9m7fqvhncb5MjvH1hlZqbn3s+x/Uk=",
         "owner": "quickshell-mirror",
         "repo": "quickshell",
-        "rev": "d4c92973b53d9fa34cc110d3b974eb6bde5b3027",
+        "rev": "fb08eced449e87e47321e95beeb890a63d2c67bd",
         "type": "github"
       },
       "original": {
@@ -1652,11 +1652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776222810,
-        "narHash": "sha256-5TD8MYqLMcJi9yV/9jq2dVUPtnu/lKZPD61esQCgvqs=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4d6fee71fea68418a48992409b47f1183d0dd111",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {
@@ -2065,11 +2065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776144279,
-        "narHash": "sha256-eX3u6wJ34+qu7ZR1qWOaToGWmudYQSOEStZZm6goP+8=",
+        "lastModified": 1776317517,
+        "narHash": "sha256-JP1XVRabZquf7pnXvRUjp7DV+EBrB6Qmp3+vG3HMy/k=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "727de8a44c85e90f899c540cf3ffa0d5d3344f9c",
+        "rev": "0a7be59e988bb2cb452080f59aaabae70bc415ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
🔄 Updating 27 inputs (excluding: lix-module, lix)

✨ Update details:
- chaotic: E%3D → ynlk%3D
- chaotic/jovian: 7txw%3D → nrPQ%3D
- chaotic/nixpkgs: R76E%3D → VRXM%3D
- chaotic/rust-overlay: gvqs%3D → fCWw%3D
- firefox: cgGk%3D → jTg%3D
- hyprland: ygkc%3D → tm0Y%3D
- nixpkgs-master: BkU4%3D → p4xM%3D
- nur: VFvk%3D → 5eUA%3D
- nvf: oEs4%3D → 4WQA%3D
- quickshell: UhvQ%3D → Uk%3D
- zen-browser: %2B8%3D → k%3D