### PR TITLE
Update flake.lock - 2026-05-04T19-11-34Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,11 +71,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1760703920,
-        "narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
+        "lastModified": 1776754714,
+        "narHash": "sha256-E3OAK27smtATTmX45uoTSRsVD+Y+ZiVVfgM/tjpbtYg=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "d646af9b7d14bff08824538164af99d0c521b185",
+        "rev": "4d508123037e7851ad36ebf7d9c48b0e9e1eb581",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777828231,
-        "narHash": "sha256-oco0/vBN7b7J8JmOBAo71Wy4jyYu1AHVe8f7OLbExQo=",
+        "lastModified": 1777916350,
+        "narHash": "sha256-9plT1sUne+opEy4JNeFAei0WJcuBlH/vNWTxAddakyU=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "2ea0d66d094727b9490f44c07a31302606e61649",
+        "rev": "1e99cf31789ada05b078d8894436e5f13828de79",
         "type": "github"
       },
       "original": {
@@ -152,12 +152,12 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1777402229,
-        "narHash": "sha256-h6WzecM2+aBt0rrcvG5+8d11q+nZoDm60na/48NcJ6w=",
-        "rev": "5ab3bee6fa77196de319a0b7669def091fc82253",
-        "revCount": 25833,
+        "lastModified": 1777918043,
+        "narHash": "sha256-Zl229Ynd484malKv6UPbbjIgRZHThLH3NugvUD63M6M=",
+        "rev": "35185ec4d4dcdfe34e08f0e48f6a66afd3b95007",
+        "revCount": 25846,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.19.0/019dd5b5-57ba-7d72-be54-93608443f096/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.19.1/019df44d-015e-7013-9fce-a0a4d4a95c7b/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1777808467,
-        "narHash": "sha256-vZs4YherE5a+bxBxZU0bIv3hAwnDeKe+1neHZH0GiY4=",
+        "lastModified": 1777910574,
+        "narHash": "sha256-tfw7AmvngoQ/Xw/TgU7PfuDRC2qnY7DJZ/3YlM+80Ec=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "5b168b741e895e50d5ae20cf2da4fe3451c7fe55",
+        "rev": "6bac30f4edef7054d1c0b478681bf1bee4b32a49",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1775176642,
-        "narHash": "sha256-2veEED0Fg7Fsh81tvVDNYR6SzjqQxa7hbi18Jv4LWpM=",
+        "lastModified": 1776136500,
+        "narHash": "sha256-r0gN2brVWA351zwMV0Flmlcd6SGMvYqFbvC3DfKFM8Y=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "179704030c5286c729b5b0522037d1d51341022c",
+        "rev": "0f8ba203d475587f477e7ae12661bd8459e225b7",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1777678872,
-        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
+        "lastModified": 1777898446,
+        "narHash": "sha256-tTEOTTjMHd8Vffn4hehLTPgOXXxJ27xfkf4DoyZgD7s=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
+        "rev": "5d82aa3d6b5da25dbfec1a995750a70a03b8c659",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777815398,
-        "narHash": "sha256-MrIhEoqXc4YsHEUfH4rDU/K09XnWcKntNhCjs7n7zi8=",
+        "lastModified": 1777913624,
+        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b5e86c1b19f178a8ee10f7cb747325e02e3d3991",
+        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
         "type": "github"
       },
       "original": {
@@ -626,11 +626,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777815398,
-        "narHash": "sha256-MrIhEoqXc4YsHEUfH4rDU/K09XnWcKntNhCjs7n7zi8=",
+        "lastModified": 1777913624,
+        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b5e86c1b19f178a8ee10f7cb747325e02e3d3991",
+        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
         "type": "github"
       },
       "original": {
@@ -755,11 +755,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1777830947,
-        "narHash": "sha256-+wHLBmwtt/75aQxqlDCOUzvOE9OzGSIazb+aeuzLLlU=",
+        "lastModified": 1777910456,
+        "narHash": "sha256-YXQ5bhn5mklMsOuVqze3QBqqL+8zsUum24Yx1K2Rb+w=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "6a7abd00379b4f37b468bc2d0e717d4ba293efe1",
+        "rev": "eff3bfe261e90b8950b59379ca7815f735a7aab6",
         "type": "github"
       },
       "original": {
@@ -1008,11 +1008,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777614199,
-        "narHash": "sha256-k8fgidVoDNQTZWGLdhe6kLgpsLcydhPzal5YKVwxD2U=",
+        "lastModified": 1777835880,
+        "narHash": "sha256-zcxPYK9s4ZazYkmO5QMi1Vcm8v8JRmeOwOm3/Yey5Tk=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "79f3e3cc5c643138b7b3405c42681451be85d838",
+        "rev": "6783eb884b9bff3bb9f206e6d4a1d9e1838bb2c9",
         "type": "github"
       },
       "original": {
@@ -1027,11 +1027,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1777209276,
-        "narHash": "sha256-P6e4ndStNEohCMmWkPdIrxkSSx0pgYm2R/wiTj0MApA=",
+        "lastModified": 1777903821,
+        "narHash": "sha256-qxDK7Mqw4wMrW+vPnR/m5Q+Ka3Mi/NnrAd63GeudcuE=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "e008ca6e656cc04608ef769a0c7589acebe6303c",
+        "rev": "734af571e94ce4e02b60eb2a97a8603ef645981d",
         "type": "github"
       },
       "original": {
@@ -1160,11 +1160,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777641297,
-        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
         "type": "github"
       },
       "original": {
@@ -1192,11 +1192,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1777894051,
+        "narHash": "sha256-gD93nlyAyOZOQ2BG1YE/xPid8eVPrwCD2UBMMjwJ1o4=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "cea90d52f99e874eb11689f4acd7951bcde3b7a0",
         "type": "github"
       },
       "original": {
@@ -1237,11 +1237,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1777833258,
-        "narHash": "sha256-hMZSfIs89wKQeqYk/kCwW62SDNJxxZOsNgY8FobQ8us=",
+        "lastModified": 1777921657,
+        "narHash": "sha256-pYNOB/XOpeZ4YJevuSK/VoSHXFlXKXHuFAxhAHUz7qg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4306abb370f9adc3b7af5fc5876708f4fe2a96b1",
+        "rev": "f36e9cf7defe7318858635ada7ce9bfcbfbf3573",
         "type": "github"
       },
       "original": {
@@ -1330,11 +1330,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -1424,11 +1424,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1777761044,
-        "narHash": "sha256-/GVBkZrt/ajcOpIo/tcUMY5IdKw2shVb3HsodbJyjgo=",
+        "lastModified": 1777891250,
+        "narHash": "sha256-XNMv5HI0uzQL+s6TOQUu/Bl0zgBRRPHPpJf1d+fhWxY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55671bd7af3540fb0b05aaeed63e76017f4b7cb5",
+        "rev": "e7b6ff4aac6041bd0ddb759f59318305c17cf0b8",
         "type": "github"
       },
       "original": {
@@ -1472,11 +1472,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1777641297,
-        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
         "type": "github"
       },
       "original": {
@@ -1494,11 +1494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777833248,
-        "narHash": "sha256-HCan3UcndGXnaiQVQeXuCyqus0/QuEd5gv3FaJ8anvQ=",
+        "lastModified": 1777921965,
+        "narHash": "sha256-g8apmrS2Ty4pvionlFs8YsU/ddbTW7AbXDeE7ed0SBM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "959ee39d0321e9f872e88fd564d5b4f5ad981ce2",
+        "rev": "c1ef7ab863e2808368b81bc90f548cb29016b958",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1519,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775228139,
-        "narHash": "sha256-ebbeHmg+V7w8050bwQOuhmQHoLOEOfqKzM1KgCTexK4=",
+        "lastModified": 1777598946,
+        "narHash": "sha256-X239dAGaU1+gfDj8jKH8GzlqKMcxaVfXOio+uzBOkeE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "601971b9c89e0304561977f2c28fa25e73aa7132",
+        "rev": "5d55af01c0f86be583931fe99207fc56c14134b3",
         "type": "github"
       },
       "original": {
@@ -1542,11 +1542,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1777831544,
-        "narHash": "sha256-3VWjbp7r84eiJM1Fqfr6LHskvpLTB70gpPP0TmEtnQs=",
+        "lastModified": 1777837065,
+        "narHash": "sha256-uRD6a4uNno3SsAw0E0E6xqbiK7pX63Ad1F37q5fyz9g=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "8530b43e14cd62a1045fe2870db790fcd48174ec",
+        "rev": "7ec206a5d9a7d5d27900d81a6bb382823902276d",
         "type": "github"
       },
       "original": {
@@ -1600,11 +1600,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777706159,
-        "narHash": "sha256-TuD8hw9lkRCEb+6v93iB7HDvcmvH8R0qyD6wBmPGfv8=",
+        "lastModified": 1777871389,
+        "narHash": "sha256-gU+VGpwGJ2vvg0mtYqVvj5u+2LteuHlpokH6JSAtueY=",
         "owner": "quickshell-mirror",
         "repo": "quickshell",
-        "rev": "8db8ca1fecfcce8def1f9265fa1742baa0e0c271",
+        "rev": "59e9c47b0eb48a9e4bcf9631fa062ee939bd2e83",
         "type": "github"
       },
       "original": {
@@ -1652,11 +1652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777778183,
-        "narHash": "sha256-Lqv9MZO0XAGcMbXJU+ULBSMD41Pf391uJehylUQKe7Y=",
+        "lastModified": 1777864665,
+        "narHash": "sha256-oE4lnjiBa3uE+dP9jM0jFzofP1xYIlK6IQBjLfWjH04=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "dbba5f888c82ef3ce594c451c33ac2474eb80847",
+        "rev": "669151bbc7f2416b622af2f48e9136e2c9da5530",
         "type": "github"
       },
       "original": {
@@ -1672,11 +1672,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775652648,
-        "narHash": "sha256-mLE7i9r9qenayJ8adWm22SbqUwLuopvRhyoizuZTtyo=",
+        "lastModified": 1777905286,
+        "narHash": "sha256-J8h1LKbK/nDyz/smOK13Yq6mY9ItBgnMDabt5RVML9U=",
         "owner": "uiriansan",
         "repo": "SilentSDDM",
-        "rev": "a0fb8a48de772c0340dd6639b331ebf6ec2eb554",
+        "rev": "8ecdd84438ada68ce4ee7ce70522d4484b103477",
         "type": "github"
       },
       "original": {
@@ -1740,11 +1740,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1777580129,
-        "narHash": "sha256-6buSTzDtHYCJP1JNAIZCmgNcOs76oN03j+21CxdijVo=",
+        "lastModified": 1777835090,
+        "narHash": "sha256-VLH8zPweblCOvpnQXp4fVs7f6Q79YhXF5XFKlOrvIFk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "20ff51f523e2dd67e5f31a321719d30708c1b771",
+        "rev": "7989a1054b01153212dede6005abfd1576b8328c",
         "type": "github"
       },
       "original": {
@@ -1892,11 +1892,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1772661346,
-        "narHash": "sha256-4eu3LqB9tPqe0Vaqxd4wkZiBbthLbpb7llcoE/p5HT0=",
+        "lastModified": 1777041405,
+        "narHash": "sha256-BAGZ7ObFV/9Z61OJZun7ifPyhkuHqNuW1QIhQ8LuzCo=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "13b5b0c299982bb361039601e2d72587d6846294",
+        "rev": "5f868b3a338b6904c47f3833b9c411be641983a8",
         "type": "github"
       },
       "original": {
@@ -1908,11 +1908,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1772934010,
-        "narHash": "sha256-x+6+4UvaG+RBRQ6UaX+o6DjEg28u4eqhVRM9kpgJGjQ=",
+        "lastModified": 1777169200,
+        "narHash": "sha256-h7dDbIzP5hDr9v97w9PL6jdAgXawmj6krcH+959rqpU=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "c3529673a5ab6e1b6830f618c45d9ce1bcdd829d",
+        "rev": "f798c2dce44ef815bb6b8f05a82135c7942d35ac",
         "type": "github"
       },
       "original": {
@@ -1924,11 +1924,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1772909925,
-        "narHash": "sha256-jx/5+pgYR0noHa3hk2esin18VMbnPSvWPL5bBjfTIAU=",
+        "lastModified": 1777463218,
+        "narHash": "sha256-Bhkozqtq3BKLqWTlmKm8uAptfX4aRGI8QX3eEL54Vpc=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "b4d3a1b3bcbd090937ef609a0a3b37237af974df",
+        "rev": "5768d08ed2e7944a26a958868cdb073cb8856dae",
         "type": "github"
       },
       "original": {
@@ -2065,11 +2065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777564084,
-        "narHash": "sha256-O9VRkxg+2j+sh+c73wi4VeIBECoqW2PlnCR9Qe1nQKA=",
+        "lastModified": 1777913180,
+        "narHash": "sha256-LjaD9lXsw3xb3Me/sWQNL3BMHavcA6KZus7kEkixkbk=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "d93443c0f6fdb3b179bed68856f322dba4842612",
+        "rev": "c17d06897a6883bfa6617880116d3e618aa9bae9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 27 inputs (excluding: lix-module, lix)

✨ Update details:
- chaotic: ExQo%3D → akyU%3D
- chaotic/home-manager: 7zi8%3D → 4FXw%3D
- chaotic/jovian: xD2U%3D → y5Tk%3D
- chaotic/nixpkgs: GxPk%3D → a9Zs%3D
- chaotic/rust-overlay: Ke7Y%3D → jH04%3D
- determinate: cJ6w%3D → 3M6M%3D
- firefox: GiY4%3D → 80Ec%3D
- firefox/lib-aggregate: MApA%3D → dcuE%3D
- firefox/lib-aggregate/nixpkgs-lib: YuhQ%3D → J1o4%3D
- firefox/nixpkgs: yjgo%3D → hWxY%3D
- flake-parts: Vbgk%3D → gD7s%3D
- home-manager: 7zi8%3D → 4FXw%3D
- hyprland: LLlU%3D → %2Bw%3D
- nixpkgs: GxPk%3D → a9Zs%3D
- nixpkgs-master: Q8us%3D → z7qg%3D
- nur: anvQ%3D → 0SBM%3D
- nvf: tnQs%3D → yz9g%3D
- quickshell: Gfv8%3D → tueY%3D
- silentSDDM: Ttyo%3D → ML9U%3D
- stylix: ijVo%3D → vIFk%3D
- stylix/base16-helix: Nwzw%3D → btYg%3D
- stylix/firefox-gnome-theme: LWpM%3D → FM8Y%3D
- stylix/nixpkgs: U%3D → RYbE%3D
- stylix/nur: exK4%3D → OkeE%3D
- stylix/tinted-schemes: 5HT0%3D → uzCo%3D
- stylix/tinted-tmux: JGjQ%3D → rqpU%3D
- stylix/tinted-zed: TIAU%3D → 4Vpc%3D
- zen-browser: nQKA%3D → xkbk%3D

### 📦 System Package Changes
```text
<<< /nix/store/axghj51q6zf10x5av2kg5fkb8ljdcq5b-nixos-system-loneros-26.05.20260501.c6d6588.drv
>>> /nix/store/ahgwnzk4var7q59iphkqpmzxywfvz98a-nixos-system-loneros-26.05.20260503.73c703c.drv
Version changes:
[C.]  #01  advanced-r5164               <none> x3 -> <none> x2
[U.]  #02  btop                         1.4.6, 1.4.6_fish-completions -> 1.4.7, 1.4.7_fish-completions
[U.]  #03  bun                          1.3.11, 1.3.11_fish-completions -> 1.3.13, 1.3.13_fish-completions
[U.]  #04  cfitsio                      4.6.3 -> 4.6.4
[U.]  #05  cli11                        2.6.1 -> 2.6.2
[C.]  #06  electron                     39.8.9 x2, 40.9.2, 41.3.0 -> 39.8.9, 40.9.2, 41.3.0
[C.]  #07  electron-unwrapped           39.8.9 x2, 40.9.2, 41.3.0 -> 39.8.9, 40.9.2, 41.3.0
[C.]  #08  ffmpeg                       <none> x7, 4.4.6, 6.1.4, 7.1.2, 7.1.3 x2, 8-support.patch, 8.0, 8.0.1 x2, 8.0.1_fish-completions -> <none> x7, 4.4.6, 6.1.4, 7.1.2, 7.1.3, 8-support.patch, 8.0, 8.0.1, 8.0.1_fish-completions
[C.]  #09  gcr                          3.41.2 x2, 3.41.2.tar.xz, 4.4.0.1 x2, 4.4.0.1.tar.xz x2 -> 3.41.2, 3.41.2.tar.xz, 4.4.0.1 x2, 4.4.0.1.tar.xz x2
[C.]  #10  gjs                          1.86.0 x3, 1.86.0.tar.xz x2 -> 1.86.0 x2, 1.86.0.tar.xz x2
[U.]  #11  go-toml                      2.3.0 -> 2.3.1
[U.]  #12  golangci-lint                2.11.4, 2.11.4_fish-completions, 2.11.4-go-modules -> 2.12.1, 2.12.1_fish-completions, 2.12.1-go-modules
[C.]  #13  gst-plugins-bad              1.26.11 x4, 1.26.11.tar.xz x3 -> 1.26.11 x3, 1.26.11.tar.xz x3
[C.]  #14  gtk4                         4.20.3 x4 -> 4.20.3 x3
[U.]  #15  hyprutils                    0.12.0 -> 0.13.0
[C.]  #16  libadwaita                   1.8.2, 1.8.5.1 x3 -> 1.8.2, 1.8.5.1 x2
[C.]  #17  libsecret                    0.21.7 x3, 0.21.7.tar.xz x2 -> 0.21.7 x2, 0.21.7.tar.xz x2
[U.]  #18  lp_solve                     5.5.2.11 -> 5.5.2.14
[U.]  #19  mesa                         26.0.5 x2 -> 26.0.6 x2
[C.]  #20  netpbm                       11.12.0, 11.13.3 x3 -> 11.12.0, 11.13.3 x2
[U.]  #21  nixos-system-loneros         26.05.20260501.c6d6588 -> 26.05.20260503.73c703c
[U.]  #22  nwg-displays                 0.3.28, 0.3.28_fish-completions -> 0.4.0, 0.4.0_fish-completions
[C.]  #23  openal-soft                  1.24.3 x4 -> 1.24.3 x3
[C.]  #24  openjdk-minimal-jre          21.0.10+7 -> 21.0.10+7 x2
[C.]  #25  pipewire                     1.4.9, 1.5.patch, 1.6.3 x3, 1.6.3_fish-completions -> 1.4.9, 1.5.patch, 1.6.3 x2, 1.6.3_fish-completions
[C.]  #26  proton-cachyos               <none>, 11.0-20260428-slr-x86_64_v3.tar.xz -> <none>, 11.0-20260429-slr-x86_64_v3.tar.xz
[U.]  #27  python3.13-tree-sitter-zeek  0.2.12 -> 0.2.13
[U.]  #28  rclone                       1.73.5, 1.73.5_fish-completions, 1.73.5-go-modules -> 1.74.0, 1.74.0_fish-completions, 1.74.0-go-modules
[C.]  #29  sdl2-compat                  2.32.60, 2.32.66 x3 -> 2.32.60, 2.32.66 x2
[C.]  #30  sdl3                         3.2.28, 3.4.2 x4 -> 3.2.28, 3.4.2 x3
[U.]  #31  sdl3-image                   3.4.2 -> 3.4.4
[C.]  #32  source                       <none> x2680 -> <none> x2682
[C.]  #33  spandsp                      0.0.6 x4, 0.0.6.tar.gz x3 -> 0.0.6 x3, 0.0.6.tar.gz x3
[C.]  #34  subversion                   1.14.5 x4, 1.14.5.tar.bz2 x3 -> 1.14.5 x3, 1.14.5.tar.bz2 x3
[U.]  #35  tauri                        2.9.6, 2.9.6-vendor, 2.9.6-vendor-staging -> 2.11.0, 2.11.0-vendor, 2.11.0-vendor-staging
[C.]  #36  wrap-gapps-hook              <none> x10 -> <none> x9
[C.]  #37  zenity                       4.2.1, 4.2.1.tar.xz, 4.2.2 x3, 4.2.2.tar.xz x2 -> 4.2.1, 4.2.1.tar.xz, 4.2.2 x2, 4.2.2.tar.xz x2
Removed packages:
[R.]  #01  Rubik-Black.ttf                  <none>
[R.]  #02  Rubik-BlackItalic.ttf            <none>
[R.]  #03  Rubik-Bold.ttf                   <none>
[R.]  #04  Rubik-BoldItalic.ttf             <none>
[R.]  #05  Rubik-ExtraBold.ttf              <none>
[R.]  #06  Rubik-ExtraBoldItalic.ttf        <none>
[R.]  #07  Rubik-Italic.ttf                 <none>
[R.]  #08  Rubik-Light.ttf                  <none>
[R.]  #09  Rubik-LightItalic.ttf            <none>
[R.]  #10  Rubik-Medium.ttf                 <none>
[R.]  #11  Rubik-MediumItalic.ttf           <none>
[R.]  #12  Rubik-Regular.ttf                <none>
[R.]  #13  Rubik-SemiBold.ttf               <none>
[R.]  #14  Rubik-SemiBoldItalic.ttf         <none>
[R.]  #15  cfitsio-pc-cmake.patch           <none>
[R.]  #16  lp_solve_5.5.2.11_source.tar.gz  <none>
[R.]  #17  openjdk-headless-minimal-jre     21.0.10+7
Closure size: 22764 -> 22730 (515 paths added, 549 paths removed, delta -34, disk usage -178.2KiB).
```