### PR TITLE
Update flake.lock - 2026-05-06T19-19-02Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778002349,
-        "narHash": "sha256-xI+Deo8fDTnux5QF9DbUIi8Hdd425wBperaxStGV8aU=",
+        "lastModified": 1778089063,
+        "narHash": "sha256-VnyVTQHpB1kdugpyxo+Mn3UAtX9KMSAUQsN9MnvRrBo=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "1b4de35cb33ca7b59eb2d8bf2f1bf9e60b665e48",
+        "rev": "babfe4cd63d26151341a16c1bc117a6c437eb8a8",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1777977906,
-        "narHash": "sha256-qglnBDKKffnbCYhdP11vuIT1JLrSHiRPbfFVQbI0lAE=",
+        "lastModified": 1778084847,
+        "narHash": "sha256-0s3bzpqMGGO+EQETSf47FDxwcZiWreIuq8S2ZWyz7rI=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "041d405e8e75806ad08f339f04d962ff4e553da3",
+        "rev": "2ac3a7cb14eb0e107db33b5d683134c1618f8ed9",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777988791,
-        "narHash": "sha256-DtbtSW5+Hls7z+D9BfsAXvFuivt5iZ0OzUXjQ8d8lB8=",
+        "lastModified": 1778009629,
+        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d987617879f613053f6fdf4491fe28ce0283d543",
+        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
         "type": "github"
       },
       "original": {
@@ -626,11 +626,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777988791,
-        "narHash": "sha256-DtbtSW5+Hls7z+D9BfsAXvFuivt5iZ0OzUXjQ8d8lB8=",
+        "lastModified": 1778009629,
+        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d987617879f613053f6fdf4491fe28ce0283d543",
+        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
         "type": "github"
       },
       "original": {
@@ -755,11 +755,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1777995176,
-        "narHash": "sha256-iq9W7sFoKFNFt0UAxRnnLVkbvNT+nJWsZQFNcWh/fCU=",
+        "lastModified": 1778072172,
+        "narHash": "sha256-onx/6cN1tHDnMH0oCQCnpQPKv9VijeLtfOh7PStp2f0=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "a531c2ed6bb4cd4eb2c6cb51838cb07a37226377",
+        "rev": "1681bea42dd2f11ba3fe6df05560d0b231de3c76",
         "type": "github"
       },
       "original": {
@@ -1160,11 +1160,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777918403,
-        "narHash": "sha256-7QiZv0LcW1yIOLo2LNuCQjWon1Z1r99FwK24hbtBOF4=",
+        "lastModified": 1778036283,
+        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afc5551119aae6eab73a95c1960891cfe63204f6",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
         "type": "github"
       },
       "original": {
@@ -1237,11 +1237,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778007428,
-        "narHash": "sha256-0AyL2KhhFaomPko/9ynrCkUxnaMkXzIn0CsUmVJ+nis=",
+        "lastModified": 1778095059,
+        "narHash": "sha256-LW2nru9+O0oyR3lfzgzFLwTibhINoIL/dx2/1dBMKWU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f0b14eeb820593227f3fcfe8896f868b800203d1",
+        "rev": "94a37dc9da62b41f0c70a91da739bc318d049c11",
         "type": "github"
       },
       "original": {
@@ -1269,11 +1269,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1777673416,
-        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "github"
       },
       "original": {
@@ -1424,11 +1424,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1777929473,
-        "narHash": "sha256-TpVPahLM+DGWN+L/k2okrIsrjTfKLjC1xVAy1zX4G0s=",
+        "lastModified": 1778060440,
+        "narHash": "sha256-5uwxUCXwDNzqIA5TWMIG9gSk1nZf+z//Wae4PLuwydw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "69710ea485067ba4ff64681ebde9bcc87f897dec",
+        "rev": "39d9e4fcf3976da8dd0d523723747ee11a3d6f7a",
         "type": "github"
       },
       "original": {
@@ -1472,11 +1472,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1777918403,
-        "narHash": "sha256-7QiZv0LcW1yIOLo2LNuCQjWon1Z1r99FwK24hbtBOF4=",
+        "lastModified": 1778036283,
+        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afc5551119aae6eab73a95c1960891cfe63204f6",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
         "type": "github"
       },
       "original": {
@@ -1494,11 +1494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778007419,
-        "narHash": "sha256-2AiFdHD1/7QcMdviiM8hjd/B0CjTaq9mejPSWJvgvWw=",
+        "lastModified": 1778094762,
+        "narHash": "sha256-X8uV6nYMkY1xKecKTC4wbTP/5EMwTvZeEuSI/LWsA1k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67ee59eeeb2ec2c275c5a7e40239904ae7fd8719",
+        "rev": "dcdd79dd589f1aa666a35da7a8fd07cf17f1527b",
         "type": "github"
       },
       "original": {
@@ -1542,11 +1542,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1777963724,
-        "narHash": "sha256-DM3sF8ikMrqPGapSOpYYtwqfYMU/xDaP/UzmmdC0lgI=",
+        "lastModified": 1778049651,
+        "narHash": "sha256-EC5pBiLcP/EVmYWldJRNfkChCqF9rkeTnTs8t9Cs+ZY=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "5dc8f3a34cf46d98f6a0073368adc2746b854cf6",
+        "rev": "88dbbad1f44efe3d2c18903e2c7542452f7bdfd6",
         "type": "github"
       },
       "original": {
@@ -1652,11 +1652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777950921,
-        "narHash": "sha256-NpOgt8ISaHTDNJZjNUfwFfbieKfRXzab4WKM31gZCGA=",
+        "lastModified": 1778037418,
+        "narHash": "sha256-EZnAOkPgEeOO2rCRhwkTvesCq/E6dbsyxhMyaefgIWM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "366ea19e0e55b768f74b7a0b2a20f847e7ae828d",
+        "rev": "adf987c76af8d17b8256d23631bcf203f81e1a63",
         "type": "github"
       },
       "original": {
@@ -2065,11 +2065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777959875,
-        "narHash": "sha256-kL2gxkGbIawygfc+DJhWBXAcRplFQlLyDBb4JHCxTzw=",
+        "lastModified": 1778047595,
+        "narHash": "sha256-RquiPUl5fViU+hHRjilVcy+5XUowINmvMfk2lNdIAg8=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "604c3c8814c87eac54d804253ab520cb8fac7b21",
+        "rev": "e361aeff090333c005bc12b3bcf3c8b44d867a4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 27 inputs (excluding: lix-module, lix)

✨ Update details:
- chaotic: V8aU%3D → RrBo%3D
- chaotic/home-manager: 8lB8%3D → 3FCg%3D
- chaotic/nixpkgs: BOF4%3D → DZCE%3D
- chaotic/rust-overlay: ZCGA%3D → gIWM%3D
- firefox: 0lAE%3D → z7rI%3D
- firefox/nixpkgs: 4G0s%3D → wydw%3D
- home-manager: 8lB8%3D → 3FCg%3D
- hyprland: fCU%3D → p2f0%3D
- nixpkgs: BOF4%3D → DZCE%3D
- nixpkgs-master: Bnis%3D → MKWU%3D
- nixpkgs-stable: ZMBs%3D → djgA%3D
- nur: gvWw%3D → sA1k%3D
- nvf: 0lgI%3D → 2BZY%3D
- zen-browser: xTzw%3D → IAg8%3D

### 📦 System Package Changes
```text
<<< /nix/store/ahgf3h636091dbxp8yqyya2y30vn5wpl-nixos-system-loneros-26.05.20260504.afc5551.drv
>>> /nix/store/qwpz3fy53hvwk3jjgyppg8vhbqz6ndd1-nixos-system-loneros-26.05.20260506.ed67bc8.drv
Version changes:
[C.]  #01  CVE                                   2014-8139.diff, 2014-8140.diff, 2014-8141.diff, 2014-9636.diff, 2014-9913.patch, 2015-7696.diff, 2015-7697.diff, 2015-7747.patch, 2016-9844.patch, 2017-6827+CVE-2017-6828+CVE-2017-6832+CVE-2017-6835+CVE-2017-6837.patch x3, 2017-6829.patch x3, 2017-6830+CVE-2017-6834+CVE-2017-6836+CVE-2017-6838.patch x3, 2017-6831.patch x3, 2017-6833.patch x3, 2017-6839.patch x3, 2017-8372-CVE-2017-8373.patch x3, 2017-8374.patch x3, 2017-10140-cwd-db_config.patch, 2017-10140-4.8-cwd-db_config.patch, 2018-13440.patch x3, 2018-17095.patch x3, 2018-18384.patch, 2019-13232-1.patch x3, 2019-13232-2.patch x3, 2019-13232-3.patch x3, 2021-3468.patch x3, 2021-3502.patch x3, 2021-4217.patch, 2021-30218.patch, 2021-30219.patch, 2021-40633.patch, 2022-24599.patch x3, 2022-28805.patch, 2022-40320.patch, 2022-47021.patch x3, 2023-1981.patch x3, 2023-38469.patch x3, 2023-38470.patch x3, 2023-38471.patch x3, 2023-38471-2.patch x3, 2023-38472.patch x3, 2023-38473.patch x3, 2023-39810.patch, 2024-6655.patch, 2024-52616.patch x3, 2024-56406.patch, 2025-4382.patch, 2025-5244.diff, 2025-5245.diff, 2025-15269.patch x3, 2025-15275.patch x3, 2025-15279_1.patch x3, 2025-15279_2.patch x3, 2025-26519_0.patch, 2025-26519_1.patch, 2025-31344.patch, 2025-40909.patch, 2025-46836.patch x3, 2025-62813.patch x3, 2025-66418.patch, 2025-66471.patch, 2026-0989.patch x3, 2026-0990.patch x3, 2026-0992.patch x3, 2026-2903.patch, 2026-6507.patch, 2026-22693.patch x3, 2026-25068.patch x3, 2026-26157_CVE-2026-26158.patch -> 2014-8139.diff, 2014-8140.diff, 2014-8141.diff, 2014-9636.diff, 2014-9913.patch, 2015-7696.diff, 2015-7697.diff, 2015-7747.patch, 2016-9844.patch, 2017-6827+CVE-2017-6828+CVE-2017-6832+CVE-2017-6835+CVE-2017-6837.patch x3, 2017-6829.patch x3, 2017-6830+CVE-2017-6834+CVE-2017-6836+CVE-2017-6838.patch x3, 2017-6831.patch x3, 2017-6833.patch x3, 2017-6839.patch x3, 2017-8372-CVE-2017-8373.patch x3, 2017-8374.patch x3, 2017-10140-cwd-db_config.patch, 2017-10140-4.8-cwd-db_config.patch, 2018-13440.patch x3, 2018-17095.patch x3, 2018-18384.patch, 2019-13232-1.patch x3, 2019-13232-2.patch x3, 2019-13232-3.patch x3, 2021-3468.patch x3, 2021-3502.patch x3, 2021-4217.patch, 2021-30218.patch, 2021-30219.patch, 2021-40633.patch, 2022-24599.patch x3, 2022-28805.patch, 2022-40320.patch, 2022-47021.patch x3, 2023-1981.patch x3, 2023-38469.patch x3, 2023-38470.patch x3, 2023-38471.patch x3, 2023-38471-2.patch x3, 2023-38472.patch x3, 2023-38473.patch x3, 2023-39810.patch, 2024-6655.patch, 2024-52616.patch x3, 2024-56406.patch, 2025-4382.patch, 2025-5244.diff, 2025-5245.diff, 2025-15269.patch x3, 2025-15275.patch x3, 2025-15279_1.patch x3, 2025-15279_2.patch x3, 2025-26519_0.patch, 2025-26519_1.patch, 2025-31344.patch, 2025-40909.patch, 2025-46836.patch x3, 2025-62813.patch x3, 2025-66418.patch, 2025-66471.patch, 2026-0989.patch x3, 2026-0990.patch x3, 2026-0992.patch x3, 2026-2903.patch, 2026-3184.patch x2, 2026-4539.patch, 2026-6507.patch, 2026-22693.patch x3, 2026-25068.patch x3, 2026-26157_CVE-2026-26158.patch, 2026-32316.patch, 2026-33947.patch, 2026-33948.patch, 2026-39979.patch, 2026-40164.patch
[U.]  #02  Cursor                                3.2.11-x86_64.AppImage -> 3.2.21-x86_64.AppImage
[U.]  #03  awww                                  0.12.0, 0.12.0_fish-completions, 0.12.0-vendor, 0.12.0-vendor-staging -> 0.12.1, 0.12.1_fish-completions, 0.12.1-vendor, 0.12.1-vendor-staging
[C.]  #04  busybox                               <none>, 1.37.0, 1.37.0.tar.bz2 -> <none>, 1.37-fix-syslogd.patch, 1.37.0, 1.37.0.tar.bz2
[U.]  #05  code-cursor-wrapper                   3.2.11, 3.2.11_fish-completions -> 3.2.21, 3.2.21_fish-completions
[C.]  #06  cryptsetup                            2.8.4, 2.8.4.tar.xz, 2.8.6 x2, 2.8.6.tar.xz x2 -> 2.8.6 x3, 2.8.6.tar.xz x3
[U.]  #07  cursor                                3.2.11-extracted -> 3.2.21-extracted
[C.]  #08  dash                                  0.5.13.1, 0.5.13.1.tar.gz, 0.5.13.2 x2, 0.5.13.2.tar.gz x2 -> 0.5.13.2 x3, 0.5.13.2.tar.gz x3
[C.]  #09  firefox                               140.5.0esr.source.tar.xz, 140.9.0esr.source.tar.xz, 152.0a1.en-US.linux-x86_64.tar.xz -> 140.9.0esr.source.tar.xz x2, 152.0a1.en-US.linux-x86_64.tar.xz
[C.]  #10  fmt                                   11.2.0, 12.0.0, 12.1.0 x2 -> 11.2.0, 12.1.0 x3
[C.]  #11  gdk-pixbuf                            2.44.5 x3, 2.44.5.tar.xz x3 -> 2.44.5 x2, 2.44.5.tar.xz x2, 2.44.6, 2.44.6.tar.xz
[C.]  #12  getent-glibc                          2.40-218, 2.42-61, 2.42-61_fish-completions -> 2.40-224, 2.42-61, 2.42-61_fish-completions
[C.]  #13  glibc                                 2.26.patch x3, 2.40.tar.xz x2, 2.40-218, 2.42 x2, 2.42.tar.xz x4, 2.42-61 x2, 2.42-61_fish-completions, 2.42-61-source-unsecvars -> 2.26.patch x3, 2.40.tar.xz x2, 2.40-224, 2.42 x2, 2.42.tar.xz x4, 2.42-61 x2, 2.42-61_fish-completions, 2.42-61-source-unsecvars
[C*]  #14  glibc-locales                         2.40-218 x3, 2.42-61 x7, 2.42-61_fish-completions -> 2.40-224 x3, 2.42-61 x7, 2.42-61_fish-completions
[C.]  #15  go                                    1.22.12-linux-amd64-bootstrap x2, 1.24.13-linux-amd64-bootstrap, 1.24.13-linux-386-bootstrap, 1.25.8, 1.25.9, 1.25.9_fish-completions, 1.26.2 x2 -> 1.22.12-linux-amd64-bootstrap x2, 1.24.13-linux-amd64-bootstrap, 1.24.13-linux-386-bootstrap, 1.25.9 x2, 1.25.9_fish-completions, 1.26.2 x2
[C.]  #16  go1.25.9.src.tar.gz                   <none> -> <none> x2
[U.]  #17  helium                                0.12.0.2, 0.12.0.2-bwrap, 0.12.0.2-extracted, 0.12.0.2-fhsenv-profile, 0.12.0.2-fhsenv-rootfs, 0.12.0.2_fish-completions, 0.12.0.2-init, 0.12.0.2-x86_64.AppImage -> 0.12.1.1, 0.12.1.1-bwrap, 0.12.1.1-extracted, 0.12.1.1-fhsenv-profile, 0.12.1.1-fhsenv-rootfs, 0.12.1.1_fish-completions, 0.12.1.1-init, 0.12.1.1-x86_64.AppImage
[U.]  #18  kazumi                                2.0.8, 2.0.8_fish-completions, 2.0.8-package-config.json, 2.0.8-package-config-with-root.json -> 2.1.0, 2.1.0_fish-completions, 2.1.0-package-config.json, 2.1.0-package-config-with-root.json
[C.]  #19  libXpm                                3.5.17.tar.xz, 3.5.18.tar.xz x2 -> 3.5.18.tar.xz x2, 3.5.19.tar.xz
[C.]  #20  libarchive                            3.8.6 x3 -> 3.8.6 x2, 3.8.7
[C.]  #21  libde265                              1.0.16, 1.0.18 x2 -> 1.0.18 x3
[C.]  #22  libjpeg-turbo                         3.1.2, 3.1.3.tar.gz, 3.1.4 x3 -> 3.1.3.tar.gz, 3.1.4 x4
[C.]  #23  libopenmpt                            0.8.5, 0.8.5+release.autotools.tar.gz, 0.8.6 x2, 0.8.6+release.autotools.tar.gz x2 -> 0.8.6 x3, 0.8.6+release.autotools.tar.gz x3
[C.]  #24  libpng                                <none>, 1.2.59, 1.2.59.tar.xz, 1.6.54-apng.patch.gz, 1.6.55.tar.xz x2, 1.6.56, 1.6.56-apng.patch.gz x2, 1.6.56.tar.xz x2, 1220aa013f0c83da3fb64ea6d327f9173fa008d10e28bc9349eac3463457723b1c66.tar.gz -> <none>, 1.2.59, 1.2.59.tar.xz, 1.6.55.tar.xz, 1.6.56, 1.6.56-apng.patch.gz x3, 1.6.56.tar.xz x3, 1220aa013f0c83da3fb64ea6d327f9173fa008d10e28bc9349eac3463457723b1c66.tar.gz
[C.]  #25  libpng-apng                           1.6.55, 1.6.56 x2 -> 1.6.56 x3
[U.]  #26  librecad                              2.2.1.4, 2.2.1.4_fish-completions -> 2.2.1.5, 2.2.1.5_fish-completions
[U.]  #27  librime-lua                           0-unstable-2026-04-26 -> 0-unstable-2026-05-02
[C.]  #28  libxpm                                3.5.17, 3.5.18 x2 -> 3.5.18 x2, 3.5.19
[U.]  #29  lix                                   2.94.1, 2.94.1_fish-completions, 2.94.1-vendor, 2.94.1-vendor-staging -> 2.94.2, 2.94.2_fish-completions, 2.94.2-vendor, 2.94.2-vendor-staging
[C.]  #30  locale-glibc                          2.40-218, 2.42-61 x2 -> 2.40-224, 2.42-61 x2
[C.]  #31  nghttp2                               1.63.0.tar.bz2, 1.67.1 x2, 1.67.1.tar.bz2 x2, 1.68.1 x6, 1.68.1.tar.bz2 x3 -> 1.63.0.tar.bz2, 1.68.1 x8, 1.68.1.tar.bz2 x4
[C.]  #32  nghttp3                               1.12.0, 1.12.0.tar.bz2, 1.15.0 x2, 1.15.0.tar.bz2 x2 -> 1.15.0 x3, 1.15.0.tar.bz2 x3
[C.]  #33  ngtcp2                                1.17.0, 1.17.0.tar.bz2, 1.20.0.tar.bz2, 1.22.0 x2, 1.22.0.tar.bz2 x2, 1.22.1 -> 1.20.0.tar.bz2, 1.22.0 x2, 1.22.0.tar.bz2 x2, 1.22.1 x2, 1.22.1.tar.bz2
[D.]  #34  niri-git                              26.04-unstable-2026-05-02, 26.04-unstable-2026-05-02_fish-completions, 26.04-unstable-2026-05-02-vendor, 26.04-unstable-2026-05-02-vendor-staging -> 0-unstable-2026-05-05, 0-unstable-2026-05-05_fish-completions, 0-unstable-2026-05-05-vendor, 0-unstable-2026-05-05-vendor-staging
[C.]  #35  nix                                   0.23.2, 0.29.0, 0.31.1, 2.34.6 x2 -> 0.23.2, 0.29.0, 0.31.1, 2.34.7 x2
[C.]  #36  nix-cmd                               2.30.4+1, 2.34.6 -> 2.30.5+1, 2.34.7
[C.]  #37  nix-expr                              2.30.4+1, 2.34.6 -> 2.30.5+1, 2.34.7
[U.]  #38  nix-expr-c                            2.34.6 -> 2.34.7
[U.]  #39  nix-expr-tests                        2.34.6 -> 2.34.7
[C.]  #40  nix-fetchers                          2.30.4+1, 2.34.6 -> 2.30.5+1, 2.34.7
[U.]  #41  nix-fetchers-c                        2.34.6 -> 2.34.7
[U.]  #42  nix-fetchers-tests                    2.34.6 -> 2.34.7
[C.]  #43  nix-flake                             2.30.4+1, 2.34.6 -> 2.30.5+1, 2.34.7
[U.]  #44  nix-flake-c                           2.34.6 -> 2.34.7
[U.]  #45  nix-flake-tests                       2.34.6 -> 2.34.7
[U.]  #46  nix-functional-tests                  2.34.6 -> 2.34.7
[C.]  #47  nix-main                              2.30.4+1, 2.34.6 -> 2.30.5+1, 2.34.7
[U.]  #48  nix-main-c                            2.34.6 -> 2.34.7
[U.]  #49  nix-manual                            2.34.6 -> 2.34.7
[U.]  #50  nix-nswrapper                         2.34.6 -> 2.34.7
[U.]  #51  nix-perl                              2.34.6 -> 2.34.7
[C.]  #52  nix-store                             2.30.4+1, 2.34.6 -> 2.30.5+1, 2.34.7
[U.]  #53  nix-store-c                           2.34.6 -> 2.34.7
[U.]  #54  nix-store-test-support                2.34.6 -> 2.34.7
[U.]  #55  nix-store-tests                       2.34.6 -> 2.34.7
[C.]  #56  nix-util                              2.30.4+1, 2.34.6 -> 2.30.5+1, 2.34.7
[U.]  #57  nix-util-c                            2.34.6 -> 2.34.7
[U.]  #58  nix-util-test-support                 2.34.6 x2 -> 2.34.7 x2
[U.]  #59  nix-util-tests                        2.34.6 -> 2.34.7
[U.]  #60  nixos-system-loneros                  26.05.20260504.afc5551 -> 26.05.20260506.ed67bc8
[U.]  #61  noctalia                              0-unstable-20260504-1dbfadd30, 0-unstable-20260504-1dbfadd30_fish-completions -> 0-unstable-20260506-8cb73cb09, 0-unstable-20260506-8cb73cb09_fish-completions
[U.]  #62  noctalia-qs                           0-unstable-20260504-d3e26ccd9 -> 0-unstable-20260506-d3e26ccd9
[C.]  #63  nss                                   3.112.3 x3, 3.119.1-with-nspr-4.38.2.tar.gz, 3.123.1 -> 3.112.3 x2, 3.112.5, 3.119.1-with-nspr-4.38.2.tar.gz, 3.123.1
[C.]  #64  nss-cacert                            3.121 x3 -> 3.121 x2, 3.123
[C.]  #65  openssh                               10.2p1, 10.2p1.tar.gz, 10.3p1 x2, 10.3p1_fish-completions, 10.3p1.tar.gz x2 -> 10.3p1 x3, 10.3p1_fish-completions, 10.3p1.tar.gz x3
[C.]  #66  openssl                               3.5.5.tar.gz x2, 3.6.1 x6, 3.6.1_fish-completions, 3.6.1.tar.gz x4 -> 3.5.5.tar.gz x2, 3.6.1 x4, 3.6.1_fish-completions, 3.6.1.tar.gz x3, 3.6.2 x2, 3.6.2.tar.gz x2
[U.]  #67  osu-lazer-bin                         2026.425.0, 2026.425.0-bwrap, 2026.425.0-extracted, 2026.425.0-fhsenv-profile, 2026.425.0-fhsenv-rootfs, 2026.425.0_fish-completions, 2026.425.0-init -> 2026.429.0, 2026.429.0-bwrap, 2026.429.0-extracted, 2026.429.0-fhsenv-profile, 2026.429.0-fhsenv-rootfs, 2026.429.0_fish-completions, 2026.429.0-init
[C.]  #68  pub-cross_file                        0.3.4+2 x2, 0.3.4+2.tar.gz x2 -> 0.3.4+2 x2, 0.3.4+2.tar.gz x2, 0.3.5+2, 0.3.5+2.tar.gz
[C.]  #69  pub-file_selector_linux               0.9.3+1, 0.9.3+1.tar.gz, 0.9.3+2, 0.9.3+2.tar.gz -> 0.9.3+1, 0.9.3+1.tar.gz, 0.9.3+2, 0.9.3+2.tar.gz, 0.9.4, 0.9.4.tar.gz
[C.]  #70  pub-file_selector_macos               0.9.4+2, 0.9.4+2.tar.gz, 0.9.4+4, 0.9.4+4.tar.gz -> 0.9.4+2, 0.9.4+2.tar.gz, 0.9.4+4, 0.9.4+4.tar.gz, 0.9.5, 0.9.5.tar.gz
[C.]  #71  pub-file_selector_platform_interface  2.6.2 x2, 2.6.2.tar.gz x2 -> 2.6.2 x2, 2.6.2.tar.gz x2, 2.7.0, 2.7.0.tar.gz
[C.]  #72  pub-file_selector_windows             0.9.3+3, 0.9.3+3.tar.gz, 0.9.3+4, 0.9.3+4.tar.gz -> 0.9.3+3, 0.9.3+3.tar.gz, 0.9.3+4, 0.9.3+4.tar.gz, 0.9.3+5, 0.9.3+5.tar.gz
[C.]  #73  pub-image_picker                      1.1.2, 1.1.2.tar.gz, 1.2.0, 1.2.0.tar.gz -> 1.1.2, 1.1.2.tar.gz, 1.2.0, 1.2.0.tar.gz, 1.2.1, 1.2.1.tar.gz
[C.]  #74  pub-image_picker_android              0.8.12+17, 0.8.12+17.tar.gz, 0.8.13+1, 0.8.13+1.tar.gz -> 0.8.12+17, 0.8.12+17.tar.gz, 0.8.13+1, 0.8.13+1.tar.gz, 0.8.13+16, 0.8.13+16.tar.gz
[C.]  #75  pub-image_picker_for_web              3.0.6, 3.0.6.tar.gz, 3.1.0, 3.1.0.tar.gz -> 3.0.6, 3.0.6.tar.gz, 3.1.0, 3.1.0.tar.gz, 3.1.1, 3.1.1.tar.gz
[C.]  #76  pub-image_picker_ios                  0.8.12+1, 0.8.12+1.tar.gz, 0.8.13, 0.8.13.tar.gz -> 0.8.12+1, 0.8.12+1.tar.gz, 0.8.13, 0.8.13.tar.gz, 0.8.13+6, 0.8.13+6.tar.gz
[C.]  #77  pub-image_picker_linux                0.2.1+1, 0.2.1+1.tar.gz, 0.2.2, 0.2.2.tar.gz -> 0.2.1+1, 0.2.1+1.tar.gz, 0.2.2 x2, 0.2.2.tar.gz x2
[C.]  #78  pub-image_picker_macos                0.2.1+1, 0.2.1+1.tar.gz, 0.2.2, 0.2.2.tar.gz -> 0.2.1+1, 0.2.1+1.tar.gz, 0.2.2, 0.2.2.tar.gz, 0.2.2+1, 0.2.2+1.tar.gz
[C.]  #79  pub-image_picker_platform_interface   2.10.0, 2.10.0.tar.gz, 2.11.1, 2.11.1.tar.gz -> 2.10.0, 2.10.0.tar.gz, 2.11.1 x2, 2.11.1.tar.gz x2
[C.]  #80  pub-image_picker_windows              0.2.1+1, 0.2.1+1.tar.gz, 0.2.2, 0.2.2.tar.gz -> 0.2.1+1, 0.2.1+1.tar.gz, 0.2.2 x2, 0.2.2.tar.gz x2
[U.]  #81  python3.13-glyphslib                  6.13.0 -> 6.13.1
[C.]  #82  python3.13-requests                   2.32.5, 2.33.1 x2 -> 2.33.1 x3
[U.]  #83  python3.13-uv                         0.11.8 -> 0.11.10
[U.]  #84  qtkeychain                            0.15.0 -> 0.16.0
[C.]  #85  spidermonkey                          140.5.0, 140.9.0 -> 140.9.0 x2
[C*]  #86  systemd                               <none>, 258.5, 260.1 x2, 260.1_fish-completions -> <none>, 258.7, 260.1 x2, 260.1_fish-completions
[C.]  #87  systemd-minimal                       258.5, 260.1 x2 -> 258.7, 260.1 x2
[C.]  #88  systemd-minimal-libs                  258.5, 260.1 x2 -> 258.7, 260.1 x2
[C.]  #89  util-linux                            2.41.3, 2.41.3.tar.xz x2, 2.42 x2, 2.42_fish-completions, 2.42.tar.xz x3 -> 2.41.4, 2.41.4.tar.xz x2, 2.42 x2, 2.42_fish-completions, 2.42.tar.xz x3
[C.]  #90  util-linux-minimal                    2.41.3, 2.42 x2 -> 2.41.4, 2.42 x2
[U.]  #91  uv                                    0.11.8, 0.11.8-vendor, 0.11.8-vendor-staging -> 0.11.10, 0.11.10-vendor, 0.11.10-vendor-staging
[C.]  #92  xz                                    1.9.jar, 1.9.pom, 5.4.7 x2, 5.4.7.tar.gz, 5.8.1 x2, 5.8.1.tar.xz, 5.8.2 x2, 5.8.2.tar.gz x2, 5.8.3 x4, 5.8.3_fish-completions, 5.8.3.tar.xz -> 1.9.jar, 1.9.pom, 5.4.7 x2, 5.4.7.tar.gz, 5.8.2 x2, 5.8.2.tar.gz x2, 5.8.3 x6, 5.8.3_fish-completions, 5.8.3.tar.xz
Added packages:
[A.]  #1  62b8f9fd0bb3b862823cd34afce4b389fbd27569.patch  <none>
[A.]  #2  pam_lastlog2-add-lpam-to-Makemodule.am.patch    <none>
Removed packages:
[R.]  #1  bits-only-build-when-cpu_set_t-is-available.patch  <none> x2
[R.]  #2  go1.25.8.src.tar.gz                                <none>
[R.]  #3  lix-lowdown                                        3.0-support.patch
[R.]  #4  pkcs11-fetchkey-error-to-debug.patch               <none>
[R.]  #5  pkcs11-fix-pinentry.patch                          <none>
[R.]  #6  pkcs11-tests-allow-module-path.patch               <none>
[R.]  #7  ssh-agent-tests-increase-timeout.patch             <none>
Closure size: 22730 -> 22759 (3686 paths added, 3657 paths removed, delta +29, disk usage +130.8KiB).
```