### PR TITLE
Update flake.lock - 2026-05-07T19-23-37Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778089063,
-        "narHash": "sha256-VnyVTQHpB1kdugpyxo+Mn3UAtX9KMSAUQsN9MnvRrBo=",
+        "lastModified": 1778178319,
+        "narHash": "sha256-VFnFGbkFV+Z3rXuyuMPfG/4Z2SyNGvM7ais5fEPoLXg=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "babfe4cd63d26151341a16c1bc117a6c437eb8a8",
+        "rev": "e5803a33bf2978e551299c434455904100d006da",
         "type": "github"
       },
       "original": {
@@ -152,12 +152,12 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1777918043,
-        "narHash": "sha256-Zl229Ynd484malKv6UPbbjIgRZHThLH3NugvUD63M6M=",
-        "rev": "35185ec4d4dcdfe34e08f0e48f6a66afd3b95007",
-        "revCount": 25846,
+        "lastModified": 1778177425,
+        "narHash": "sha256-oyHvP5HDRe59opmjTrq2ED9lh+R9FrHyaCGPPNfBqWM=",
+        "rev": "f0ccb960d3ad5bff28acd9cabf8bdef885b5d52f",
+        "revCount": 25858,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.19.1/019df44d-015e-7013-9fce-a0a4d4a95c7b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.20.0/019e03bc-3f83-7833-aba3-b691ef4956c7/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778084847,
-        "narHash": "sha256-0s3bzpqMGGO+EQETSf47FDxwcZiWreIuq8S2ZWyz7rI=",
+        "lastModified": 1778178391,
+        "narHash": "sha256-3fiokInjaA6dUrWFURcchhqSsdd49qN6+8qGbydweg8=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "2ac3a7cb14eb0e107db33b5d683134c1618f8ed9",
+        "rev": "f1002970ad0c5250b80e80320830383ff04fba97",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778009629,
-        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
+        "lastModified": 1778144356,
+        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
+        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
         "type": "github"
       },
       "original": {
@@ -626,11 +626,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778009629,
-        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
+        "lastModified": 1778144356,
+        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
+        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
         "type": "github"
       },
       "original": {
@@ -648,11 +648,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1777594677,
+        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
         "type": "github"
       },
       "original": {
@@ -755,11 +755,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778072172,
-        "narHash": "sha256-onx/6cN1tHDnMH0oCQCnpQPKv9VijeLtfOh7PStp2f0=",
+        "lastModified": 1778180476,
+        "narHash": "sha256-88/YUQycyDZYh808qdV7SUUgDjZdPU/njHZ5+9FDdAw=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "1681bea42dd2f11ba3fe6df05560d0b231de3c76",
+        "rev": "c18186a519d188a3ae8caf9947a5420a25590b82",
         "type": "github"
       },
       "original": {
@@ -1008,11 +1008,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777963407,
-        "narHash": "sha256-54aKHEfOllEWvTs0HYR5Lb8HIPLxfHGY4GswlfUChtQ=",
+        "lastModified": 1778172518,
+        "narHash": "sha256-YE8qTqnGTcnFUAvRi8XTM3pHWebrK6GLy9Os4iOJPko=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "ca0970551a092fd69fdbb31ef3ea2dfe15f96349",
+        "rev": "3251531a37b09db4b03f48fbf1bc9348ea9ac045",
         "type": "github"
       },
       "original": {
@@ -1160,11 +1160,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -1237,11 +1237,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778095059,
-        "narHash": "sha256-LW2nru9+O0oyR3lfzgzFLwTibhINoIL/dx2/1dBMKWU=",
+        "lastModified": 1778181784,
+        "narHash": "sha256-1MalmYrgmJzU7viLSzC44Bft95eBQIPU3iI1Zk4idnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94a37dc9da62b41f0c70a91da739bc318d049c11",
+        "rev": "7f2656d8edbd39b7124f91411c630b8b7945a0d9",
         "type": "github"
       },
       "original": {
@@ -1424,11 +1424,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778060440,
-        "narHash": "sha256-5uwxUCXwDNzqIA5TWMIG9gSk1nZf+z//Wae4PLuwydw=",
+        "lastModified": 1778157832,
+        "narHash": "sha256-KDidG68ivbHpI9mwl9NK4gARAROxEy3bZPe2BBo5ZyM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "39d9e4fcf3976da8dd0d523723747ee11a3d6f7a",
+        "rev": "ec299c6a33eee9baf5b4d72881ca2f15c06b4f01",
         "type": "github"
       },
       "original": {
@@ -1472,11 +1472,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -1494,11 +1494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778094762,
-        "narHash": "sha256-X8uV6nYMkY1xKecKTC4wbTP/5EMwTvZeEuSI/LWsA1k=",
+        "lastModified": 1778179956,
+        "narHash": "sha256-iH+mze/AtU1OkPVjg9gPpq0/L+2bx8E7UgQ0cEftP8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcdd79dd589f1aa666a35da7a8fd07cf17f1527b",
+        "rev": "29df34c7e79c5830df78876a7a839756ce40bc50",
         "type": "github"
       },
       "original": {
@@ -1600,11 +1600,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777871389,
-        "narHash": "sha256-gU+VGpwGJ2vvg0mtYqVvj5u+2LteuHlpokH6JSAtueY=",
+        "lastModified": 1778148537,
+        "narHash": "sha256-sxY5HMSXCI4GtYrYZF+t+QIsdkDVrl0HxcXwklsXYik=",
         "owner": "quickshell-mirror",
         "repo": "quickshell",
-        "rev": "59e9c47b0eb48a9e4bcf9631fa062ee939bd2e83",
+        "rev": "b93d61385fa3478e039c56f9d69c8c749a4f0989",
         "type": "github"
       },
       "original": {
@@ -1652,11 +1652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778037418,
-        "narHash": "sha256-EZnAOkPgEeOO2rCRhwkTvesCq/E6dbsyxhMyaefgIWM=",
+        "lastModified": 1778123869,
+        "narHash": "sha256-hV9D8ET33kXjdoMXBT2bwM/j8WQM1SP/dVKZtjQKhAQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "adf987c76af8d17b8256d23631bcf203f81e1a63",
+        "rev": "592e5dedf04f0eaff1ed0f01ce5db7407d9fc7be",
         "type": "github"
       },
       "original": {
@@ -1740,11 +1740,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1777835090,
-        "narHash": "sha256-VLH8zPweblCOvpnQXp4fVs7f6Q79YhXF5XFKlOrvIFk=",
+        "lastModified": 1778104276,
+        "narHash": "sha256-/DSSnU0LLmOTG/OCgGwYpxP6+5YvxRx2g/GhI4x6aCU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7989a1054b01153212dede6005abfd1576b8328c",
+        "rev": "18ed8d270231e067fe2739998479ed5d7c659c2c",
         "type": "github"
       },
       "original": {
@@ -2065,11 +2065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778047595,
-        "narHash": "sha256-RquiPUl5fViU+hHRjilVcy+5XUowINmvMfk2lNdIAg8=",
+        "lastModified": 1778181873,
+        "narHash": "sha256-oc2uE+IQJaYnFBuv9Hj/dBDQ/du0ymrVl1f7aMJwZxc=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "e361aeff090333c005bc12b3bcf3c8b44d867a4f",
+        "rev": "9fe7b9c816b18f7371f7d9b17920eb5249659514",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 27 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: RrBo%3D → oLXg%3D
- chaotic/home-manager: 3FCg%3D → g%3D
- chaotic/jovian: ChtQ%3D → JPko%3D
- chaotic/nixpkgs: DZCE%3D → ymOo%3D
- chaotic/rust-overlay: gIWM%3D → KhAQ%3D
- determinate: 3M6M%3D → BqWM%3D
- firefox: z7rI%3D → weg8%3D
- firefox/nixpkgs: wydw%3D → 5ZyM%3D
- home-manager: 3FCg%3D → g%3D
- hyprland: p2f0%3D → DdAw%3D
- nixpkgs: DZCE%3D → ymOo%3D
- nixpkgs-master: MKWU%3D → idnA%3D
- nur: sA1k%3D → tP8Q%3D
- quickshell: tueY%3D → XYik%3D
- stylix: vIFk%3D → 6aCU%3D
- zen-browser: IAg8%3D → wZxc%3D
- zen-browser/home-manager: Z7rc%3D → e1RI%3D

### 📦 System Package Changes
```text
<<< /nix/store/qwpz3fy53hvwk3jjgyppg8vhbqz6ndd1-nixos-system-loneros-26.05.20260506.ed67bc8.drv
>>> /nix/store/rw0d3y8qq4gy3cpjrvb476d4rs22rchp-nixos-system-loneros-26.05.20260507.68a8af9.drv
Version changes:
[U.]  #01  apache-httpd                2.4.66 -> 2.4.67
[U.]  #02  cachyos                     7.0.3-1.tar.gz -> 7.0.4-1.tar.gz
[U.]  #03  cpupower                    7.0.3, 7.0.3_fish-completions -> 7.0.4, 7.0.4_fish-completions
[U.]  #04  fish                        4.6.0, 4.6.0_fish-completions -> 4.7.0, 4.7.0_fish-completions
[C.]  #05  get_patch                   <none> x6 -> <none> x4
[U.]  #06  ghostty-unstable            20260505085939-f9a9d33, 20260505085939-f9a9d33_fish-completions -> 20260507085604-063ac3e, 20260507085604-063ac3e_fish-completions
[U.]  #07  golangci-lint               2.12.1, 2.12.1_fish-completions, 2.12.1-go-modules -> 2.12.2, 2.12.2_fish-completions, 2.12.2-go-modules
[U.]  #08  httpd                       2.4.66.tar.bz2 -> 2.4.67.tar.bz2
[U.]  #09  incus                       6.23.0, 6.23.0-go-modules -> 7.0.0, 7.0.0-go-modules
[U.]  #10  incus-client                6.23.0, 6.23.0_fish-completions, 6.23.0-go-modules -> 7.0.0, 7.0.0_fish-completions, 7.0.0-go-modules
[U*]  #11  initrd-linux                7.0.3 -> 7.0.4
[C*]  #12  linux                       6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.3 x2, 7.0.3-modules, 7.0.3-modules-shrunk -> 6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.4 x2, 7.0.4-modules, 7.0.4-modules-shrunk
[U.]  #13  mangohud                    0.8.2 x2, 0.8.2_fish-completions -> 0.8.3 x2, 0.8.3_fish-completions
[U.]  #14  nixos-system-loneros        26.05.20260506.ed67bc8 -> 26.05.20260507.68a8af9
[U.]  #15  noctalia                    0-unstable-20260506-8cb73cb09, 0-unstable-20260506-8cb73cb09_fish-completions -> 0-unstable-20260507-cc50c4f2e, 0-unstable-20260507-cc50c4f2e_fish-completions
[U.]  #16  noctalia-qs                 0-unstable-20260506-d3e26ccd9 -> 0-unstable-20260507-d3e26ccd9
[U.]  #17  nvidia-kernel-modules       595.71.05-7.0.3 -> 595.71.05-7.0.4
[U.]  #18  python3.13-textual          8.2.4 -> 8.2.5
[C.]  #19  source                      <none> x2682 -> <none> x2684
[U.]  #20  wayland-protocols-unstable  20260429011417-e193660 -> 20260507092540-ad2e022
[U.]  #21  zed-editor                  1.0.0, 1.0.0_fish-completions, 1.0.0-vendor, 1.0.0-vendor-staging -> 1.1.5, 1.1.5_fish-completions, 1.1.5-vendor, 1.1.5-vendor-staging
Added packages:
[A.]  #01  doc-authorization_Fix-reference-to-old-manager-relation.patch                    <none>
[A.]  #02  doc-devices-disk_Fix-broken-link.patch                                           <none>
[A.]  #03  incusd-cluster_Re-order-evacuations-to-happen-earlier-on-shutdown.patch          <none>
[A.]  #04  incusd-device-nic_bridged_Fix-swapped-IPv4-IPv6-DNS-record.patch                 <none>
[A.]  #05  incusd-forknet_Add-jitter-to-DHCPv6-renewal.patch                                <none>
[A.]  #06  incusd-forknet_Include-FQDN-in-DHCPv6-INFO-requests.patch                        <none>
[A.]  #07  incusd-forknet_Persist-DHCPv6-client-DUID-across-restarts.patch                  <none>
[A.]  #08  incusd-forknet_Properly-renew-stateful-DHCPv6.patch                              <none>
[A.]  #09  incusd-instance-lxc_Fix-swap=false-failure.patch                                 <none>
[A.]  #10  incusd-instance-qemu_Fix-version-detection-for-qemu-kvm.patch                    <none>
[A.]  #11  incusd-instance-qemu_Remove-deprecated-QEMU-flag.patch                           <none>
[A.]  #12  incusd-network-acl_Fix-issue-with-instances-in-different-project-than-ACL.patch  <none>
[A.]  #13  incusd-projects_Fix-targeting-on-project-delete.patch                            <none>
[A.]  #14  incusd_Re-introduce-core-scheduling-detection.patch                              <none>
[A.]  #15  test-network_acl_Add-test-for-ACL-used-by-instance-in-different-project.patch    <none>
Closure size: 22759 -> 22774 (629 paths added, 614 paths removed, delta +15, disk usage +174.9KiB).
```