### PR TITLE
Update flake.lock - 2026-05-09T18-42-11Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778264788,
-        "narHash": "sha256-Ys9jBBS1zevFB/6GjVuQ7IpKmSaEBu/HKSGE2ijQ5q0=",
+        "lastModified": 1778345811,
+        "narHash": "sha256-fljCY5SbzHJyR2tu5UBh9kk0TEBfbVmly95uiZRrVXA=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "cd65d7842eed9229cf5590ccde07ef57925bcaa0",
+        "rev": "15b4e492345b419d71f825b2f73c1754eb48ebfa",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778260948,
-        "narHash": "sha256-x5DD8mZVi37YiGPGv78DC3fLpyooZ93BNZ/lxwtL4Hc=",
+        "lastModified": 1778327405,
+        "narHash": "sha256-v0Gt67MOSTVxK8PjSf6frks/Rfo6HMhPVNSXTgmCzss=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "0d2e11bd2bce4257f0b3d819983746235abb0ef0",
+        "rev": "d7e4a162b2eb563fa359ad9128a6be1fc8d530f3",
         "type": "github"
       },
       "original": {
@@ -755,11 +755,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778265294,
-        "narHash": "sha256-11LpGGWFOmlIneEjtQ14kqmbnx0d/UphAQLG2bPz2XU=",
+        "lastModified": 1778333727,
+        "narHash": "sha256-RGYGbW6aH3jUwGVB9BrSYcKsQj7Dl2K32ao5aWbTK40=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "1a164704e7596d743dfeade3946385997254b019",
+        "rev": "af923e30d1d24f1f4a4f5cb8308065173c1d9539",
         "type": "github"
       },
       "original": {
@@ -1237,11 +1237,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778266801,
-        "narHash": "sha256-GfMu/9vR0tXi2qFMCOJH9DLWAXV8couS+3CCWiZnWUI=",
+        "lastModified": 1778351894,
+        "narHash": "sha256-7r2iJchc8Ujmld6pd3nQFXE504Ur1apvZaZBdoA/YD4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18ef923e1cda79408e9f8501d707fd21d8ed46cb",
+        "rev": "2e8afb433747d87eba54496f93f90f41ee1adeab",
         "type": "github"
       },
       "original": {
@@ -1472,11 +1472,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -1494,11 +1494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778265402,
-        "narHash": "sha256-3r7NjmZnNP0lB52W5PrECYXVpEffiImGx8NQ9+DqDgQ=",
+        "lastModified": 1778349768,
+        "narHash": "sha256-Dg4HXJkg1sSdnPGIrEr+N7VCb3HhF6ipBVxCMrgXPz4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "214eb1569af01942c8263e6b1ca95882fb930687",
+        "rev": "e4f6e40d8ea9395f956faed44c4af68f0837a136",
         "type": "github"
       },
       "original": {
@@ -1652,11 +1652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778210054,
-        "narHash": "sha256-iYINsX0BVDxTXd0z4FzDpBYHZ9fWUtwjG9cKSXwe9Tg=",
+        "lastModified": 1778296574,
+        "narHash": "sha256-DVmg1JCjG0VJTa+FF6tH6tkQChaxzK1EzPL98RiRWU0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bc83d66023d19fb301ee98772643b24b6129ef48",
+        "rev": "1d634a90dffb59ec9ba52652de311b15528c1595",
         "type": "github"
       },
       "original": {
@@ -2065,11 +2065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778218381,
-        "narHash": "sha256-mhxT7KkmM0h/vgr84o2p6gkzm21b5/dCnIMVKaoXU+I=",
+        "lastModified": 1778343639,
+        "narHash": "sha256-HHRwiRJlbVLkj5lu/0m1+bczp8Oe0BsC87lpdDnbJOw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "ea79f20a194de74504821ab53e93c0cf92690f00",
+        "rev": "e6bdec08f8b1836c9f241c08ae3f03bbec34dbf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 27 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: Q5q0%3D → rVXA%3D
- chaotic/rust-overlay: e9Tg%3D → RWU0%3D
- firefox: L4Hc%3D → Czss%3D
- hyprland: z2XU%3D → TK40%3D
- nixpkgs: ymOo%3D → Q1MM%3D
- nixpkgs-master: nWUI%3D → YD4%3D
- nur: qDgQ%3D → XPz4%3D
- zen-browser: %2BI%3D → bJOw%3D

### 📦 System Package Changes
```text
<<< /nix/store/wpnqj6xhzs8kqzdyyig4rnpz5gxzhyl4-nixos-system-loneros-26.05.20260507.68a8af9.drv
>>> /nix/store/wij6f5af2gzbwdb9ggbmbv9s4hxk0m46-nixos-system-loneros-26.05.20260508.b3da656.drv
Version changes:
[C.]  #01  5862a6f5b5cd7ed5a7ce2af01e44747c36318220.patch  <none> x2 -> <none>
[U.]  #02  asciinema                                       2.4.0, 2.4.0_fish-completions -> 3.2.0, 3.2.0_fish-completions, 3.2.0-vendor, 3.2.0-vendor-staging
[U.]  #03  breeze-icons                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[C.]  #04  buf                                             1.68.4, 1.68.4-go-modules, 1.69.0, 1.69.0-go-modules -> 1.69.0, 1.69.0-go-modules
[C.]  #05  dart-sass                                       1.99.0 x2, 1.99.0-package-config.json, 1.99.0-package-config-with-root.json -> 1.99.0, 1.99.0-package-config.json, 1.99.0-package-config-with-root.json
[C.]  #06  electron                                        39.8.9, 40.9.2, 41.3.0 -> 39.8.9 x2, 40.9.2, 41.3.0
[C.]  #07  electron-unwrapped                              39.8.9, 40.9.2, 41.3.0 -> 39.8.9 x2, 40.9.2, 41.3.0
[C.]  #08  extra-cmake-modules                             5.116.0 x2, 5.116.0.tar.xz x2, 6.25.0, 6.25.0.tar.xz -> 5.116.0, 5.116.0.tar.xz, 6.26.0, 6.26.0.tar.xz
[U.]  #09  feh                                             3.12.1 -> 3.12.2
[U.]  #10  fish                                            4.7.0, 4.7.0_fish-completions -> 4.7.1, 4.7.1_fish-completions
[U.]  #11  freerdp                                         3.24.2 -> 3.26.0
[U.]  #12  ghostty-unstable                                20260507085604-063ac3e, 20260507085604-063ac3e_fish-completions -> 20260509161257-a330ee9, 20260509161257-a330ee9_fish-completions
[C.]  #13  go                                              1.22.12-linux-amd64-bootstrap x2, 1.24.13-linux-amd64-bootstrap, 1.24.13-linux-386-bootstrap, 1.25.9 x2, 1.25.9_fish-completions, 1.26.2 x2 -> 1.22.12-linux-amd64-bootstrap x2, 1.24.13-linux-amd64-bootstrap, 1.24.13-linux-386-bootstrap, 1.25.9, 1.25.10, 1.25.10_fish-completions, 1.26.2 x2
[C.]  #14  go1.25.9.src.tar.gz                             <none> x2 -> <none>
[U.]  #15  hyprpicker                                      0.4.6, 0.4.6_fish-completions -> 0.4.7, 0.4.7_fish-completions
[U.]  #16  jujutsu                                         0.40.0, 0.40.0_fish-completions, 0.40.0-vendor, 0.40.0-vendor-staging -> 0.41.0, 0.41.0_fish-completions, 0.41.0-vendor, 0.41.0-vendor-staging
[U.]  #17  karchive                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #18  kauth                                           6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #19  kbookmarks                                      6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #20  kcmutils                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #21  kcodecs                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #22  kcolorscheme                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #23  kcompletion                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #24  kconfig                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #25  kconfigwidgets                                  6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #26  kcontacts                                       6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #27  kcoreaddons                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #28  kcrash                                          6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #29  kdbusaddons                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #30  kdeclarative                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #31  kdeconnect-kde                                  26.04.0, 26.04.0_fish-completions, 26.04.0.tar.xz -> 26.04.1, 26.04.1_fish-completions, 26.04.1.tar.xz
[U.]  #32  kdoctools                                       6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #33  kglobalaccel                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #34  kguiaddons                                      6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #35  ki18n                                           6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #36  kiconthemes                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #37  kimageformats                                   6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #38  kio                                             6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #39  kirigami                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #40  kirigami-wrapped                                6.25.0 -> 6.26.0
[U.]  #41  kitemmodels                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #42  kitemviews                                      6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #43  kjobwidgets                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #44  knotifications                                  6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #45  kpackage                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #46  kparts                                          6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #47  kpeople                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #48  kservice                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #49  kstatusnotifieritem                             6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #50  ksvg                                            6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #51  ktextwidgets                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #52  kwallet                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #53  kwidgetsaddons                                  6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #54  kwindowsystem                                   6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #55  kxmlgui                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #56  lego                                            4.31.0, 4.31.0-go-modules -> 4.35.2, 4.35.2-go-modules
[C.]  #57  libinput                                        1.29.2 x2, 1.29.2_fish-completions -> 1.29.2, 1.31.1, 1.31.1_fish-completions
[U.]  #58  libphonenumber                                  9.0.29 -> 9.0.30
[C.]  #59  libplacebo                                      5.264.1 x2, 7.351.0 -> 5.264.1 x2, 7.360.1
[U.]  #60  mesa                                            26.0.6 x2 -> 26.1.0 x2
[U.]  #61  modemmanager-qt                                 6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #62  mpd                                             0.24.9, 0.24.9_fish-completions -> 0.24.10, 0.24.10_fish-completions
[U.]  #63  nixos-system-loneros                            26.05.20260507.68a8af9 -> 26.05.20260508.b3da656
[U.]  #64  noctalia                                        0-unstable-20260508-20b6b16ab, 0-unstable-20260508-20b6b16ab_fish-completions -> 0-unstable-20260509-96b5ce586, 0-unstable-20260509-96b5ce586_fish-completions
[U.]  #65  noctalia-qs                                     0-unstable-20260508-d3e26ccd9 -> 0-unstable-20260509-d3e26ccd9
[C.]  #66  offline                                         <none> x6 -> <none> x7
[U.]  #67  python3.13-uv                                   0.11.10 -> 0.11.11
[U.]  #68  qqc2-desktop-style                              6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[C.]  #69  skip_broken_tests.patch                         <none> x2 -> <none>
[U.]  #70  solid                                           6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #71  sonnet                                          6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #72  sops                                            3.12.2, 3.12.2_fish-completions, 3.12.2-go-modules -> 3.13.0, 3.13.0_fish-completions, 3.13.0-go-modules
[U.]  #73  syntax-highlighting                             6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #74  tailscale                                       1.96.5, 1.96.5_fish-completions, 1.96.5-go-modules -> 1.98.0, 1.98.0_fish-completions, 1.98.0-go-modules
[U.]  #75  telegram-desktop                                6.7.6, 6.7.6_fish-completions -> 6.7.8, 6.7.8_fish-completions
[U.]  #76  telegram-desktop-unwrapped                      6.7.6 -> 6.7.8
[U.]  #77  terraform                                       1.15.0, 1.15.0_fish-completions, 1.15.0-go-modules -> 1.15.2, 1.15.2_fish-completions, 1.15.2-go-modules
[U.]  #78  uv                                              0.11.10, 0.11.10-vendor, 0.11.10-vendor-staging -> 0.11.11, 0.11.11-vendor, 0.11.11-vendor-staging
[C.]  #79  yarn                                            1.22.22 -> 1.22.22, 4.14-support.patch
[C.]  #80  yarn-berry                                      4-fetcher-1.2.3, 4-fetcher-1.2.3-vendor, 4-fetcher-1.2.3-vendor-staging, 4.13.0 -> 4-fetcher-1.2.3, 4-fetcher-1.2.3-vendor, 4-fetcher-1.2.3-vendor-staging, 4.13.0, 4.14.1
[C.]  #81  yarn-berry-config-hook                          <none> -> <none> x2
[C.]  #82  yarn-berry-offline                              4.13.0 -> 4.13.0, 4.14.1
[U.]  #83  zed-editor                                      1.1.5, 1.1.5_fish-completions, 1.1.5-vendor, 1.1.5-vendor-staging -> 1.1.6, 1.1.6_fish-completions, 1.1.6-vendor, 1.1.6-vendor-staging
Added packages:
[A.]  #1  54e844748029d4874e14d0c086d50092c04c8899...c08d99437ec8bb56a703f04ad1ef199502c62d10.diff  <none>
[A.]  #2  go1.25.10.src.tar.gz                                                                      <none>
Closure size: 22779 -> 22782 (784 paths added, 781 paths removed, delta +3, disk usage +202.3KiB).
```