### PR TITLE
Update flake.lock - 2026-05-10T18-43-31Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778264788,
-        "narHash": "sha256-Ys9jBBS1zevFB/6GjVuQ7IpKmSaEBu/HKSGE2ijQ5q0=",
+        "lastModified": 1778432182,
+        "narHash": "sha256-GKMj2ahDJOwJbrQr1vVQ3/Eb+Prri+nPwOfX+TY3zbU=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "cd65d7842eed9229cf5590ccde07ef57925bcaa0",
+        "rev": "ac354d5e8b3eea3cc68bcf4ff0e09b67fd665ddb",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778260948,
-        "narHash": "sha256-x5DD8mZVi37YiGPGv78DC3fLpyooZ93BNZ/lxwtL4Hc=",
+        "lastModified": 1778418994,
+        "narHash": "sha256-HLECyZz3lKWbOJ4ZjM4ZPuLwC1OkRUHC4IFPhiKj/L8=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "0d2e11bd2bce4257f0b3d819983746235abb0ef0",
+        "rev": "0e57ea9490bb49cbf6f77059901758418c633b60",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778248595,
-        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
+        "lastModified": 1778365864,
+        "narHash": "sha256-ImoT/wqmgMImf2dAC+E0MverAdA4QXsedOeES9B7Ezw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
+        "rev": "2f419037039a152448c5f4ae9494154753d1b399",
         "type": "github"
       },
       "original": {
@@ -626,11 +626,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778248595,
-        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
+        "lastModified": 1778365864,
+        "narHash": "sha256-ImoT/wqmgMImf2dAC+E0MverAdA4QXsedOeES9B7Ezw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
+        "rev": "2f419037039a152448c5f4ae9494154753d1b399",
         "type": "github"
       },
       "original": {
@@ -755,11 +755,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778265294,
-        "narHash": "sha256-11LpGGWFOmlIneEjtQ14kqmbnx0d/UphAQLG2bPz2XU=",
+        "lastModified": 1778425782,
+        "narHash": "sha256-RQDuCRFmAfTsc/laI5rx/Z5qZjW9BykkbgpNr5GpvAw=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "1a164704e7596d743dfeade3946385997254b019",
+        "rev": "7a1af5032614cb1ece893faca7706375a66e6c04",
         "type": "github"
       },
       "original": {
@@ -1008,11 +1008,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778172518,
-        "narHash": "sha256-YE8qTqnGTcnFUAvRi8XTM3pHWebrK6GLy9Os4iOJPko=",
+        "lastModified": 1778408709,
+        "narHash": "sha256-DKIuvXXnv4+2wN+AY1qGfQ4uv/2dsOluMCCDEJCJ00g=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "3251531a37b09db4b03f48fbf1bc9348ea9ac045",
+        "rev": "6d7bfd32efacd9a06c36df65f47c875395547977",
         "type": "github"
       },
       "original": {
@@ -1123,11 +1123,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778240325,
-        "narHash": "sha256-d2HIS7LpfI0lgxiXCXLjxrHl3eIdNvAVexOu0xiM488=",
+        "lastModified": 1778393439,
+        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "dd2d0e3f6ba00af01b9498f5697173bdc2524bee",
+        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
         "type": "github"
       },
       "original": {
@@ -1160,11 +1160,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -1237,11 +1237,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778266801,
-        "narHash": "sha256-GfMu/9vR0tXi2qFMCOJH9DLWAXV8couS+3CCWiZnWUI=",
+        "lastModified": 1778438027,
+        "narHash": "sha256-gzdJTJg8/2r0cduU75ucZqz2SUkbx7t+uhWB/QaHSjw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18ef923e1cda79408e9f8501d707fd21d8ed46cb",
+        "rev": "722903c533644f8b36345fb9a1f931570739d075",
         "type": "github"
       },
       "original": {
@@ -1317,11 +1317,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-fN6ynMvcdwPDB09LpWJNO5ogu+HFydrBWXJywoI/NNg=",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "lastModified": 1777954456,
+        "narHash": "sha256-qeRNZKcA0igTdRVnBe6hyo49CqxME92s4G8Sr78ARJw=",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre990025.15f4ee454b1d/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre992384.549bd84d6279/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -1424,11 +1424,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778228972,
-        "narHash": "sha256-L34YTBob9sdjnc+rd7nMC2X8ddw0LT4RfufnlFyArRU=",
+        "lastModified": 1778401622,
+        "narHash": "sha256-+0rgLm/T6U2I/0KrgUOz5471i6nDVFMihe4Vy/eAmNk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c5503ba41146fb6b49ed9706823b30de7f3a78f",
+        "rev": "eeac4f06ba6d4c5540c4838d13b31a2cbe0e104b",
         "type": "github"
       },
       "original": {
@@ -1472,11 +1472,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -1494,11 +1494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778265402,
-        "narHash": "sha256-3r7NjmZnNP0lB52W5PrECYXVpEffiImGx8NQ9+DqDgQ=",
+        "lastModified": 1778438187,
+        "narHash": "sha256-0motMlZYTFFlsHpBTUvTKSJIqRGHG9nOnMTqWchhB7o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "214eb1569af01942c8263e6b1ca95882fb930687",
+        "rev": "ce659861df34041cd0cb1eaf894855ffd258eeff",
         "type": "github"
       },
       "original": {
@@ -1542,11 +1542,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1778049651,
-        "narHash": "sha256-EC5pBiLcP/EVmYWldJRNfkChCqF9rkeTnTs8t9Cs+ZY=",
+        "lastModified": 1778408907,
+        "narHash": "sha256-QXjdRz5fssxAWDrtfBYxvjMtTqJzQAbnAmX3u22xCck=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "88dbbad1f44efe3d2c18903e2c7542452f7bdfd6",
+        "rev": "e86a92e4b29b499e5f1285b737b7612115103da9",
         "type": "github"
       },
       "original": {
@@ -1652,11 +1652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778210054,
-        "narHash": "sha256-iYINsX0BVDxTXd0z4FzDpBYHZ9fWUtwjG9cKSXwe9Tg=",
+        "lastModified": 1778383025,
+        "narHash": "sha256-UK7s2LJS1YwIMFL7PSaNJvLXT9pyRgm7X+HNPgMXiEE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bc83d66023d19fb301ee98772643b24b6129ef48",
+        "rev": "4568a557ca325ff81fb354382d4a9968daa1001a",
         "type": "github"
       },
       "original": {
@@ -1709,11 +1709,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1777789800,
-        "narHash": "sha256-XHCvLGu/bEEZRzXVKFu1i+2YB102Nr00n8e7xrzsfVs=",
+        "lastModified": 1778395012,
+        "narHash": "sha256-A/VRiNFQIwGp8cOC/8yNCRexFHjtFCzBwhajrkyGojo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "d0e921cc48aab6137d203a3eab19601dc2bdc0c3",
+        "rev": "3b4991bfc064c3361957f23141351ae2d9833234",
         "type": "github"
       },
       "original": {
@@ -2065,11 +2065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778218381,
-        "narHash": "sha256-mhxT7KkmM0h/vgr84o2p6gkzm21b5/dCnIMVKaoXU+I=",
+        "lastModified": 1778394798,
+        "narHash": "sha256-/jR8bModWv0ji305ecMgAB+2eaXLZiYdH+9Z4JIRkuA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "ea79f20a194de74504821ab53e93c0cf92690f00",
+        "rev": "45bc54456044b96492923739bfae633e1a4352e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 27 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: Q5q0%3D → 3zbU%3D
- chaotic/home-manager: yLpc%3D → 7Ezw%3D
- chaotic/jovian: JPko%3D → J00g%3D
- chaotic/nixpkgs: ymOo%3D → Q1MM%3D
- chaotic/rust-overlay: e9Tg%3D → XiEE%3D
- firefox: L4Hc%3D → L8%3D
- firefox/nixpkgs: ArRU%3D → AmNk%3D
- home-manager: yLpc%3D → 7Ezw%3D
- hyprland: z2XU%3D → pvAw%3D
- nix-index-database: M488%3D → J3Wc%3D
- nixpkgs: ymOo%3D → Q1MM%3D
- nixpkgs-master: nWUI%3D → HSjw%3D
- nur: qDgQ%3D → hB7o%3D
- nvf: 2BZY%3D → xCck%3D
- spicetify-nix: sfVs%3D → Gojo%3D
- spicetify-nix/nixpkgs: NNg%3D → ARJw%3D
- zen-browser: %2BI%3D → RkuA%3D

### 📦 System Package Changes
```text
<<< /nix/store/pg882whdd39lnhigfcr5cjcbk4pcandk-nixos-system-loneros-26.05.20260507.68a8af9.drv
>>> /nix/store/fwxbz5010jscgmqq8qz9p7g3g1pfjckb-nixos-system-loneros-26.05.20260508.b3da656.drv
Version changes:
[C.]  #01  5862a6f5b5cd7ed5a7ce2af01e44747c36318220.patch  <none> x2 -> <none>
[U.]  #02  asciinema                                       2.4.0, 2.4.0_fish-completions -> 3.2.0, 3.2.0_fish-completions, 3.2.0-vendor, 3.2.0-vendor-staging
[U.]  #03  breeze-icons                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[C.]  #04  buf                                             1.68.4, 1.68.4-go-modules, 1.69.0, 1.69.0-go-modules -> 1.69.0, 1.69.0-go-modules
[C.]  #05  dart-sass                                       1.99.0 x2, 1.99.0-package-config.json, 1.99.0-package-config-with-root.json -> 1.99.0, 1.99.0-package-config.json, 1.99.0-package-config-with-root.json
[C.]  #06  electron                                        39.8.9, 40.9.2, 41.3.0 -> 39.8.9 x2, 40.9.2, 41.3.0
[C.]  #07  electron-unwrapped                              39.8.9, 40.9.2, 41.3.0 -> 39.8.9 x2, 40.9.2, 41.3.0
[C.]  #08  extra-cmake-modules                             5.116.0 x2, 5.116.0.tar.xz x2, 6.25.0, 6.25.0.tar.xz -> 5.116.0, 5.116.0.tar.xz, 6.26.0, 6.26.0.tar.xz
[U.]  #09  feh                                             3.12.1 -> 3.12.2
[U.]  #10  fish                                            4.7.0, 4.7.0_fish-completions -> 4.7.1, 4.7.1_fish-completions
[U.]  #11  freerdp                                         3.24.2 -> 3.26.0
[U.]  #12  ghostty-unstable                                20260507085604-063ac3e, 20260507085604-063ac3e_fish-completions -> 20260510140212-ce6a00b, 20260510140212-ce6a00b_fish-completions
[C.]  #13  go                                              1.22.12-linux-amd64-bootstrap x2, 1.24.13-linux-amd64-bootstrap, 1.24.13-linux-386-bootstrap, 1.25.9 x2, 1.25.9_fish-completions, 1.26.2 x2 -> 1.22.12-linux-amd64-bootstrap x2, 1.24.13-linux-amd64-bootstrap, 1.24.13-linux-386-bootstrap, 1.25.9, 1.25.10, 1.25.10_fish-completions, 1.26.2 x2
[C.]  #14  go1.25.9.src.tar.gz                             <none> x2 -> <none>
[U.]  #15  hyprpicker                                      0.4.6, 0.4.6_fish-completions -> 0.4.7, 0.4.7_fish-completions
[U.]  #16  jujutsu                                         0.40.0, 0.40.0_fish-completions, 0.40.0-vendor, 0.40.0-vendor-staging -> 0.41.0, 0.41.0_fish-completions, 0.41.0-vendor, 0.41.0-vendor-staging
[U.]  #17  karchive                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #18  kauth                                           6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #19  kbookmarks                                      6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #20  kcmutils                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #21  kcodecs                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #22  kcolorscheme                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #23  kcompletion                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #24  kconfig                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #25  kconfigwidgets                                  6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #26  kcontacts                                       6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #27  kcoreaddons                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #28  kcrash                                          6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #29  kdbusaddons                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #30  kdeclarative                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #31  kdeconnect-kde                                  26.04.0, 26.04.0_fish-completions, 26.04.0.tar.xz -> 26.04.1, 26.04.1_fish-completions, 26.04.1.tar.xz
[U.]  #32  kdoctools                                       6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #33  kglobalaccel                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #34  kguiaddons                                      6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #35  ki18n                                           6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #36  kiconthemes                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #37  kimageformats                                   6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #38  kio                                             6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #39  kirigami                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #40  kirigami-wrapped                                6.25.0 -> 6.26.0
[U.]  #41  kitemmodels                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #42  kitemviews                                      6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #43  kjobwidgets                                     6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #44  knotifications                                  6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #45  kpackage                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #46  kparts                                          6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #47  kpeople                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #48  kservice                                        6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #49  kstatusnotifieritem                             6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #50  ksvg                                            6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #51  ktextwidgets                                    6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #52  kwallet                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #53  kwidgetsaddons                                  6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #54  kwindowsystem                                   6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #55  kxmlgui                                         6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #56  lego                                            4.31.0, 4.31.0-go-modules -> 4.35.2, 4.35.2-go-modules
[C.]  #57  libinput                                        1.29.2 x2, 1.29.2_fish-completions -> 1.29.2, 1.31.1, 1.31.1_fish-completions
[U.]  #58  libphonenumber                                  9.0.29 -> 9.0.30
[C.]  #59  libplacebo                                      5.264.1 x2, 7.351.0 -> 5.264.1 x2, 7.360.1
[U.]  #60  mesa                                            26.0.6 x2 -> 26.1.0 x2
[U.]  #61  modemmanager-qt                                 6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #62  mpd                                             0.24.9, 0.24.9_fish-completions -> 0.24.10, 0.24.10_fish-completions
[U.]  #63  niri-git                                        0-unstable-2026-05-08, 0-unstable-2026-05-08_fish-completions, 0-unstable-2026-05-08-vendor, 0-unstable-2026-05-08-vendor-staging -> 0-unstable-2026-05-10, 0-unstable-2026-05-10_fish-completions, 0-unstable-2026-05-10-vendor, 0-unstable-2026-05-10-vendor-staging
[U.]  #64  nixos-system-loneros                            26.05.20260507.68a8af9 -> 26.05.20260508.b3da656
[U.]  #65  noctalia                                        0-unstable-20260508-20b6b16ab, 0-unstable-20260508-20b6b16ab_fish-completions -> 0-unstable-20260510-b62f6fead, 0-unstable-20260510-b62f6fead_fish-completions
[U.]  #66  noctalia-qs                                     0-unstable-20260508-d3e26ccd9 -> 0-unstable-20260510-d8327a723
[C.]  #67  offline                                         <none> x6 -> <none> x7
[U.]  #68  python3.13-uv                                   0.11.10 -> 0.11.11
[U.]  #69  qqc2-desktop-style                              6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[C.]  #70  skip_broken_tests.patch                         <none> x2 -> <none>
[U.]  #71  solid                                           6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #72  sonnet                                          6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #73  sops                                            3.12.2, 3.12.2_fish-completions, 3.12.2-go-modules -> 3.13.0, 3.13.0_fish-completions, 3.13.0-go-modules
[U.]  #74  syntax-highlighting                             6.25.0, 6.25.0.tar.xz -> 6.26.0, 6.26.0.tar.xz
[U.]  #75  tailscale                                       1.96.5, 1.96.5_fish-completions, 1.96.5-go-modules -> 1.98.0, 1.98.0_fish-completions, 1.98.0-go-modules
[U.]  #76  telegram-desktop                                6.7.6, 6.7.6_fish-completions -> 6.7.8, 6.7.8_fish-completions
[U.]  #77  telegram-desktop-unwrapped                      6.7.6 -> 6.7.8
[U.]  #78  terraform                                       1.15.0, 1.15.0_fish-completions, 1.15.0-go-modules -> 1.15.2, 1.15.2_fish-completions, 1.15.2-go-modules
[U.]  #79  uv                                              0.11.10, 0.11.10-vendor, 0.11.10-vendor-staging -> 0.11.11, 0.11.11-vendor, 0.11.11-vendor-staging
[C.]  #80  yarn                                            1.22.22 -> 1.22.22, 4.14-support.patch
[C.]  #81  yarn-berry                                      4-fetcher-1.2.3, 4-fetcher-1.2.3-vendor, 4-fetcher-1.2.3-vendor-staging, 4.13.0 -> 4-fetcher-1.2.3, 4-fetcher-1.2.3-vendor, 4-fetcher-1.2.3-vendor-staging, 4.13.0, 4.14.1
[C.]  #82  yarn-berry-config-hook                          <none> -> <none> x2
[C.]  #83  yarn-berry-offline                              4.13.0 -> 4.13.0, 4.14.1
[U.]  #84  zed-editor                                      1.1.5, 1.1.5_fish-completions, 1.1.5-vendor, 1.1.5-vendor-staging -> 1.1.6, 1.1.6_fish-completions, 1.1.6-vendor, 1.1.6-vendor-staging
Added packages:
[A.]  #1  54e844748029d4874e14d0c086d50092c04c8899...c08d99437ec8bb56a703f04ad1ef199502c62d10.diff  <none>
[A.]  #2  go1.25.10.src.tar.gz                                                                      <none>
Closure size: 22795 -> 22798 (803 paths added, 800 paths removed, delta +3, disk usage +202.3KiB).
```