### PR TITLE
Update flake.lock - 2026-05-11T19-25-49Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778432182,
-        "narHash": "sha256-GKMj2ahDJOwJbrQr1vVQ3/Eb+Prri+nPwOfX+TY3zbU=",
+        "lastModified": 1778524396,
+        "narHash": "sha256-pt2DTQ2bQApojqz7qDgMLyoDIOUfm5nCTGceQ9nDEL8=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "ac354d5e8b3eea3cc68bcf4ff0e09b67fd665ddb",
+        "rev": "7361e951877b5f066c9a5f2bb96df2c40ba06a35",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778418994,
-        "narHash": "sha256-HLECyZz3lKWbOJ4ZjM4ZPuLwC1OkRUHC4IFPhiKj/L8=",
+        "lastModified": 1778525902,
+        "narHash": "sha256-2mBgMarGJBFWnqJMvnI60T3gYDxzi7m+kNE4/aVdD2g=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "0e57ea9490bb49cbf6f77059901758418c633b60",
+        "rev": "0942b6551aead83e426d7754545a48c6df840132",
         "type": "github"
       },
       "original": {
@@ -560,11 +560,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778365864,
-        "narHash": "sha256-ImoT/wqmgMImf2dAC+E0MverAdA4QXsedOeES9B7Ezw=",
+        "lastModified": 1778503501,
+        "narHash": "sha256-08L/X4/do7nET4rzidJ76eV/1r+mB7DchVpdPypsghc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f419037039a152448c5f4ae9494154753d1b399",
+        "rev": "85ba629c79449badf4338117c27f0ee92b4b9f1a",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778365864,
-        "narHash": "sha256-ImoT/wqmgMImf2dAC+E0MverAdA4QXsedOeES9B7Ezw=",
+        "lastModified": 1778503501,
+        "narHash": "sha256-08L/X4/do7nET4rzidJ76eV/1r+mB7DchVpdPypsghc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f419037039a152448c5f4ae9494154753d1b399",
+        "rev": "85ba629c79449badf4338117c27f0ee92b4b9f1a",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778425782,
-        "narHash": "sha256-RQDuCRFmAfTsc/laI5rx/Z5qZjW9BykkbgpNr5GpvAw=",
+        "lastModified": 1778504983,
+        "narHash": "sha256-F70mt2snAYPobaMEEGRJmCqOmqU/zDM31HldpMUIWi0=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "7a1af5032614cb1ece893faca7706375a66e6c04",
+        "rev": "5e441cae538c9396f2ee30338419bec12969608c",
         "type": "github"
       },
       "original": {
@@ -1086,11 +1086,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1777903821,
-        "narHash": "sha256-qxDK7Mqw4wMrW+vPnR/m5Q+Ka3Mi/NnrAd63GeudcuE=",
+        "lastModified": 1778419596,
+        "narHash": "sha256-ZepYJSEyrVAlyP6wuwcRfRO/cbVJAEQKpsfIzSNQrtc=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "734af571e94ce4e02b60eb2a97a8603ef645981d",
+        "rev": "7a173490ace3bb1b53e310525686d9a34614f4a8",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1778458615,
+        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
         "type": "github"
       },
       "original": {
@@ -1251,11 +1251,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777894051,
-        "narHash": "sha256-gD93nlyAyOZOQ2BG1YE/xPid8eVPrwCD2UBMMjwJ1o4=",
+        "lastModified": 1778379128,
+        "narHash": "sha256-+yjPmoKsTqe/FQHriXzIfI0ELuEt3+1LXc0BE8nU/Yc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "cea90d52f99e874eb11689f4acd7951bcde3b7a0",
+        "rev": "e361b0ff94723bc94283566dc2a13a46f07eaf5c",
         "type": "github"
       },
       "original": {
@@ -1296,11 +1296,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778438027,
-        "narHash": "sha256-gzdJTJg8/2r0cduU75ucZqz2SUkbx7t+uhWB/QaHSjw=",
+        "lastModified": 1778527471,
+        "narHash": "sha256-GVBzwqSiYfhNukBS/Ix1gRTE2DTBRYoPrNVAGV7Oqw8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "722903c533644f8b36345fb9a1f931570739d075",
+        "rev": "85676b222a7a18e2ee1e64a2a916201abe2b8889",
         "type": "github"
       },
       "original": {
@@ -1328,11 +1328,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
         "type": "github"
       },
       "original": {
@@ -1483,11 +1483,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778401622,
-        "narHash": "sha256-+0rgLm/T6U2I/0KrgUOz5471i6nDVFMihe4Vy/eAmNk=",
+        "lastModified": 1778491576,
+        "narHash": "sha256-9YOHDS9ANGbRmf3DSQ9UCvas3CyYNIBwBkKGQZTLXGY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eeac4f06ba6d4c5540c4838d13b31a2cbe0e104b",
+        "rev": "1174f92bf37f1a5914be77e1b44482d6fbc75ecc",
         "type": "github"
       },
       "original": {
@@ -1531,11 +1531,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1778458615,
+        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
         "type": "github"
       },
       "original": {
@@ -1553,11 +1553,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778438187,
-        "narHash": "sha256-0motMlZYTFFlsHpBTUvTKSJIqRGHG9nOnMTqWchhB7o=",
+        "lastModified": 1778526614,
+        "narHash": "sha256-APNv9zacmOtd3iaS19wu6uoYM2RbUIMGKhjZ6rnhtDA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce659861df34041cd0cb1eaf894855ffd258eeff",
+        "rev": "231794627a0324b5e5e4407a3fdaaf806862a642",
         "type": "github"
       },
       "original": {
@@ -1659,11 +1659,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778222427,
-        "narHash": "sha256-6GFiP611nEJvtm+m03sMyfaVIJ9QOCi//hS+PPKyyPA=",
+        "lastModified": 1778488696,
+        "narHash": "sha256-QSWgYuZUCNUJ/cxmaq83WkcT7lHQDDfsPVgH+96kIl0=",
         "owner": "quickshell-mirror",
         "repo": "quickshell",
-        "rev": "d1760ed1f31c02a95b37a9bf4084129c829ebe7f",
+        "rev": "7d1c9a9c6721606b129829134d6f614f015621e2",
         "type": "github"
       },
       "original": {
@@ -1712,11 +1712,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778383025,
-        "narHash": "sha256-UK7s2LJS1YwIMFL7PSaNJvLXT9pyRgm7X+HNPgMXiEE=",
+        "lastModified": 1778469574,
+        "narHash": "sha256-NTZzJ7xJvMXOonYqut3WLUhryeZj5QuuL0ANcqS7d30=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4568a557ca325ff81fb354382d4a9968daa1001a",
+        "rev": "4852a8aa041c94af55e136cde5b8b6d42c3563e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 28 inputs (excluding: lix-module, lix)

✨ Update details:
- chaotic: 3zbU%3D → DEL8%3D
- chaotic/home-manager: 7Ezw%3D → sghc%3D
- chaotic/nixpkgs: Q1MM%3D → 5kwg%3D
- chaotic/rust-overlay: XiEE%3D → 7d30%3D
- firefox: L8%3D → dD2g%3D
- firefox/lib-aggregate: dcuE%3D → Qrtc%3D
- firefox/lib-aggregate/nixpkgs-lib: J1o4%3D → Yc%3D
- firefox/nixpkgs: AmNk%3D → LXGY%3D
- git-hooks: RHN8%3D → flKs%3D
- home-manager: 7Ezw%3D → sghc%3D
- hyprland: pvAw%3D → IWi0%3D
- nixpkgs: Q1MM%3D → 5kwg%3D
- nixpkgs-master: HSjw%3D → Oqw8%3D
- nixpkgs-stable: djgA%3D → fi8Q%3D
- nur: hB7o%3D → htDA%3D
- quickshell: yyPA%3D → kIl0%3D

### 📦 System Package Changes
```text
<<< /nix/store/fwxbz5010jscgmqq8qz9p7g3g1pfjckb-nixos-system-loneros-26.05.20260508.b3da656.drv
>>> /nix/store/cqyrrjc4y13qijnj0zya22af2pnxd85s-nixos-system-loneros-26.05.20260511.c6e5ca3.drv
Version changes:
[C.]  #01  aws-sdk-cpp                 1.11.647 x2 -> 1.11.647
[C.]  #02  boost                       1.87.0 x3, 1.88.0, 1.89.patch x3, 1.89.0 x5 -> 1.87.0 x3, 1.88.0, 1.89.patch x2, 1.89.0 x5
[U.]  #03  cachyos                     7.0.5-1.tar.gz -> 7.0.6-1.tar.gz
[U.]  #04  cpupower                    7.0.5, 7.0.5_fish-completions -> 7.0.6, 7.0.6_fish-completions
[C.]  #05  electron                    39.8.9 x2, 40.9.2, 41.3.0 -> 39.8.9, 40.9.2, 41.3.0
[C.]  #06  electron-unwrapped          39.8.9 x2, 40.9.2, 41.3.0 -> 39.8.9, 40.9.2, 41.3.0
[U.]  #07  ghostty-unstable            20260510140212-ce6a00b, 20260510140212-ce6a00b_fish-completions -> 20260511135427-b0f8276, 20260511135427-b0f8276_fish-completions
[U.]  #08  hyprutils                   0.13.0 -> 0.13.1
[U*]  #09  initrd-linux                7.0.5 -> 7.0.6
[C*]  #10  linux                       6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.5 x2, 7.0.5-modules, 7.0.5-modules-shrunk -> 6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.6 x2, 7.0.6-modules, 7.0.6-modules-shrunk
[C.]  #11  lowdown                     3.0-compat-2.28-2.30.patch, 3.0.1, 3.0.1.tar.gz -> 3.0.1, 3.0.1.tar.gz
[C.]  #12  nix-cmd                     2.30.5+1, 2.34.7 -> 2.34.7
[C.]  #13  nix-expr                    2.30.5+1, 2.34.7 -> 2.34.7
[C.]  #14  nix-fetchers                2.30.5+1, 2.34.7 -> 2.34.7
[C.]  #15  nix-flake                   2.30.5+1, 2.34.7 -> 2.34.7
[C.]  #16  nix-main                    2.30.5+1, 2.34.7 -> 2.34.7
[C.]  #17  nix-store                   2.30.5+1, 2.34.7 -> 2.34.7
[C.]  #18  nix-util                    2.30.5+1, 2.34.7 -> 2.34.7
[U.]  #19  nixd                        2.9.0, 2.9.0_fish-completions -> 2.9.1, 2.9.1_fish-completions
[U.]  #20  nixf                        2.9.0 -> 2.9.1
[U.]  #21  nixos-system-loneros        26.05.20260508.b3da656 -> 26.05.20260511.c6e5ca3
[U.]  #22  nixt                        2.9.0 -> 2.9.1
[U.]  #23  nvidia-kernel-modules       595.71.05-7.0.5 -> 595.71.05-7.0.6
[C.]  #24  offline                     <none> x7 -> <none> x6
[C.]  #25  pnpm                        10.29.2, 10.29.2.tgz, 10.33.2 x2, 10.33.2.tgz -> 10.29.2, 10.29.2.tgz, 10.33.4 x2, 10.33.4.tgz
[U.]  #26  qtstyleplugin-kvantum       1.1.6, 1.1.6_fish-completions -> 1.1.7, 1.1.7_fish-completions
[U.]  #27  qtstyleplugin-kvantum5      1.1.6, 1.1.6_fish-completions -> 1.1.7, 1.1.7_fish-completions
[U.]  #28  rime-wanxiang               15.6.1 -> 15.9.12
[C.]  #29  source                      <none> x2686 -> <none> x2680
[U.]  #30  spotify                     1.2.82.428.g0ac8be2b-92.snap -> 1.2.84.475.ga1a748ff-93.snap
[U.]  #31  telegram-desktop            6.7.8, 6.7.8_fish-completions -> 6.8.1, 6.8.1_fish-completions
[U.]  #32  telegram-desktop-unwrapped  6.7.8 -> 6.8.1
[U.]  #33  uriparser                   1.0.1 -> 1.0.2
[U.]  #34  wayland-unstable            20260414121151-25da99a -> 20260428221954-c072ae6
[C.]  #35  yarn-berry                  4-fetcher-1.2.3, 4-fetcher-1.2.3-vendor, 4-fetcher-1.2.3-vendor-staging, 4.13.0, 4.14.1 -> 4-fetcher-1.2.3, 4-fetcher-1.2.3-vendor, 4-fetcher-1.2.3-vendor-staging, 4.14.1
[C.]  #36  yarn-berry-config-hook      <none> x2 -> <none>
[C.]  #37  yarn-berry-offline          4.13.0, 4.14.1 -> 4.14.1
[U.]  #38  zed-editor                  1.1.6, 1.1.6_fish-completions, 1.1.6-vendor, 1.1.6-vendor-staging -> 1.1.7, 1.1.7_fish-completions, 1.1.7-vendor, 1.1.7-vendor-staging
Removed packages:
[R.]  #1  jdupes                 1.31.1 x2
[R.]  #2  libjodycode            4.1.2 x2
[R.]  #3  source-patched-source  <none>
Closure size: 22798 -> 22771 (208 paths added, 235 paths removed, delta -27, disk usage +73.1KiB).
```