### PR TITLE
Update flake.lock - 2026-05-14T19-25-52Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778689271,
-        "narHash": "sha256-W6ifAg4VFRQzNXcx7YYQ75tCrXar9N96XDGDnJ3hyck=",
+        "lastModified": 1778759479,
+        "narHash": "sha256-zOk4Vt8RFn5fMcnGNeIMduIj18ZXfHhJ1VhooiA+LcQ=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "8544308a6c8efc5085bc46b6a200e510101e88f6",
+        "rev": "a4ea82b729e37e4532d0e597fe88134bf649c831",
         "type": "github"
       },
       "original": {
@@ -373,11 +373,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778681890,
-        "narHash": "sha256-RK4sTgei29wBzLu+e4ljeixKutWhbMygFsdxdFKpZOU=",
+        "lastModified": 1778781368,
+        "narHash": "sha256-t7GW8f4So0b+ATPACjTkCy9UesbSidDW3X9w3utVC1A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7654d90b94bab7eba3a52fd6f73b3f5a4c544fa2",
+        "rev": "c68d2a24376da3860ef161373d91348b1542356b",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778683849,
-        "narHash": "sha256-fKMHYZexPtUUVVvGRake8HE0qXxSdKCtUGdNYqRFNec=",
+        "lastModified": 1778767344,
+        "narHash": "sha256-KJutpgkxREVjkYmWortGonNMfFTzTlUlFLPqnqrsqsw=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "998d3af07f57603710674e7cb337b0814d925caf",
+        "rev": "a45fc64935e77bdcfdfb1166904db45a813ee4d4",
         "type": "github"
       },
       "original": {
@@ -1296,11 +1296,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778698858,
-        "narHash": "sha256-5N0kka4pTEQz07u2qF2R5aSA+2RofOMfe8KM7paL730=",
+        "lastModified": 1778786436,
+        "narHash": "sha256-tMZKYtpt1KprFa4q0+zgk2mpw3Nf/xT90o+2iBibVMg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d86f4eb2397e09434828a853780b3ce1de8a593",
+        "rev": "7eddd3b2a7f73b263245b8bb7ac2563604150f46",
         "type": "github"
       },
       "original": {
@@ -1483,11 +1483,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778672786,
-        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
+        "lastModified": 1778729098,
+        "narHash": "sha256-17SbusskVZng4nwevRqsWNJf27nMG7UczvtgWTUJttg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
+        "rev": "39ea44cddd5060b8cd413ed5e13c6af61f302283",
         "type": "github"
       },
       "original": {
@@ -1531,11 +1531,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778580735,
-        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
+        "lastModified": 1778672786,
+        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
+        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
         "type": "github"
       },
       "original": {
@@ -1553,11 +1553,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778700142,
-        "narHash": "sha256-IitqaECUTevEYZ8XcQJnRxalZxmP1TgbC71B4nUBa5g=",
+        "lastModified": 1778785149,
+        "narHash": "sha256-3YdjBsYMSEAAIN0PKb4Hv4Fp0sZpYL1NtmcEwKowHs4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c3cd6ab8bea9fba01b5a53cebbc6a2783df2800",
+        "rev": "a88319fbd475583f2da830ad60effd89c4bd42a3",
         "type": "github"
       },
       "original": {
@@ -1601,11 +1601,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1778697893,
-        "narHash": "sha256-FRDDot0l7uTmZKzU1WLKbaY16idh9xBwcM3Ft8rzZYE=",
+        "lastModified": 1778784436,
+        "narHash": "sha256-YZtyd/3pdFcei72GtffA0OFjBf6x2cJQ1LEBIAcNMCk=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "ab459445197cf957498111bec530f58e7049df4b",
+        "rev": "8b000238aa8c4727296c456a734f7ad63c2e236e",
         "type": "github"
       },
       "original": {
@@ -1800,11 +1800,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1778680030,
-        "narHash": "sha256-1TY2s0CWtT0gl7bQmZUPEA6pmRBPCfPj7DNzHIXydG0=",
+        "lastModified": 1778776709,
+        "narHash": "sha256-YhnEcpiY6+l3RFA+cPmdTaeODGvNRuqE8B7VBjPVIxo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3401cf7a7d2ce7a3e3180ed4e7225056e7a05c7d",
+        "rev": "e8ea85b4f7dddda9603e0f1ac86cd92cee3b2819",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 28 inputs (excluding: lix-module, lix)

✨ Update details:
- firefox: hyck%3D → BLcQ%3D
- firefox/nixpkgs: z0FQ%3D → Jttg%3D
- flake-parts: ioCQ%3D → hzi4%3D
- home-manager: pZOU%3D → VC1A%3D
- hyprland: FNec%3D → sqsw%3D
- nixpkgs: HgpE%3D → z0FQ%3D
- nixpkgs-master: L730%3D → bVMg%3D
- nur: Ba5g%3D → wHs4%3D
- nvf: zZYE%3D → NMCk%3D
- stylix: ydG0%3D → VIxo%3D

### 📦 System Package Changes
```text
<<< /nix/store/472s78ywqisvqdkhi8yf2k1v683zy7yp-nixos-system-loneros-26.05.20260512.48d91f2.drv
>>> /nix/store/q3g0qvgwcqzj2vq3rb5j1aqxig4qj2vx-nixos-system-loneros-26.05.20260513.eef00df.drv
Version changes:
[U.]  #01  caddy                       2.11.2, 2.11.2_fish-completions, 2.11.2-go-modules -> 2.11.3, 2.11.3_fish-completions, 2.11.3-go-modules
[U.]  #02  helium                      0.12.2.1, 0.12.2.1-bwrap, 0.12.2.1-extracted, 0.12.2.1-fhsenv-profile, 0.12.2.1-fhsenv-rootfs, 0.12.2.1_fish-completions, 0.12.2.1-init, 0.12.2.1-x86_64.AppImage -> 0.12.3.1, 0.12.3.1-bwrap, 0.12.3.1-extracted, 0.12.3.1-fhsenv-profile, 0.12.3.1-fhsenv-rootfs, 0.12.3.1_fish-completions, 0.12.3.1-init, 0.12.3.1-x86_64.AppImage
[U.]  #03  layer-shell-qt              6.6.4, 6.6.4.tar.xz -> 6.6.5, 6.6.5.tar.xz
[U.]  #04  libplasma                   6.6.4, 6.6.4.tar.xz -> 6.6.5, 6.6.5.tar.xz
[U.]  #05  nixos-system-loneros        26.05.20260512.48d91f2 -> 26.05.20260513.eef00df
[U.]  #06  noctalia                    0-unstable-20260513-22b1073d7, 0-unstable-20260513-22b1073d7_fish-completions -> 0-unstable-20260514-a9c8801f4, 0-unstable-20260514-a9c8801f4_fish-completions
[U.]  #07  noctalia-qs                 0-unstable-20260513-d8327a723 -> 0-unstable-20260514-d8327a723
[C.]  #08  nodejs                      22.22.2 x2, 22.22.2-source x2, 24.14.1 x2, 24.14.1_fish-completions, 24.14.1-source x2 -> 22.22.2 x2, 22.22.2-source x2, 22.22.3, 22.22.3-source, 24.14.1 x2, 24.14.1_fish-completions, 24.14.1-source x2
[C.]  #09  nodejs-install-executables  <none> x4 -> <none> x5
[C.]  #10  nodejs-slim                 22.22.2, 24.14.1 x2 -> 22.22.2, 22.22.3, 24.14.1 x2
[U.]  #11  noto-fonts                  2026.04.01 -> 2026.05.01
[U.]  #12  noto-fonts-lgc-plus         2026.04.01 -> 2026.05.01
[C.]  #13  npm-config-hook             <none> x4 -> <none> x5
[C.]  #14  npm-install-hook            <none> x4 -> <none> x5
[U.]  #15  plasma-activities           6.6.4, 6.6.4.tar.xz -> 6.6.5, 6.6.5.tar.xz
[C.]  #16  src                         <none> x2 -> <none> x3
[U.]  #17  vicinae                     0.20.15, 0.20.15_fish-completions -> 0.21.0, 0.21.0_fish-completions
Added packages:
[A.]  #1  node-v22.22.3.tar.xz  <none>
[A.]  #2  pnpm-fixup-state-db   1.0.0 x2, 1.0.0-npm-deps
Closure size: 22774 -> 22785 (135 paths added, 124 paths removed, delta +11, disk usage +86.2KiB).
```