### PR TITLE
Update flake.lock - 2026-05-15T19-14-06Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778695759,
-        "narHash": "sha256-HheXy8W6AAh+hh+Sf7o7EAeuvbGSW4Zirf2XjchdOXY=",
+        "lastModified": 1778867960,
+        "narHash": "sha256-TOQb4wa+hql3X/uLGHsIFaNURVXoe9VJ1kCzmREPYqQ=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "4cf22aaef1fcd0d48a249486436d139f3e9e1b19",
+        "rev": "a27bfaeab1570c84e6ff4bcc515cfff6606238ad",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778759479,
-        "narHash": "sha256-zOk4Vt8RFn5fMcnGNeIMduIj18ZXfHhJ1VhooiA+LcQ=",
+        "lastModified": 1778846096,
+        "narHash": "sha256-1Qy1XCFaIpNMDOCXDP/Rsxe9pwXHcBBjzd5KY7foNA8=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "a4ea82b729e37e4532d0e597fe88134bf649c831",
+        "rev": "f119607765683ae1fb3940b53b0feab06dd70407",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778681890,
-        "narHash": "sha256-RK4sTgei29wBzLu+e4ljeixKutWhbMygFsdxdFKpZOU=",
+        "lastModified": 1778858474,
+        "narHash": "sha256-uOh5fCoxOgdFa50WymuhCwJKuEVv/Eo4VYjK0SgzlPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7654d90b94bab7eba3a52fd6f73b3f5a4c544fa2",
+        "rev": "ca77575d39c908de876c10f93704532689df546f",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778781368,
-        "narHash": "sha256-t7GW8f4So0b+ATPACjTkCy9UesbSidDW3X9w3utVC1A=",
+        "lastModified": 1778858474,
+        "narHash": "sha256-uOh5fCoxOgdFa50WymuhCwJKuEVv/Eo4VYjK0SgzlPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c68d2a24376da3860ef161373d91348b1542356b",
+        "rev": "ca77575d39c908de876c10f93704532689df546f",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777594677,
-        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
+        "lastModified": 1778805320,
+        "narHash": "sha256-nGFJ01m2CTBKD4ABtcY4vLhHrRN91LKr/pn41PcU78A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
+        "rev": "9846abe15e7d0d36b8acbd4d05f2b87461744c92",
         "type": "github"
       },
       "original": {
@@ -726,11 +726,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1777612004,
-        "narHash": "sha256-C9fgvjBUktvQpc8g5kBZcuqDfFRlZdbRSeSaLxLcfoE=",
+        "lastModified": 1778816896,
+        "narHash": "sha256-Ou7c/yiqpogckLnuvLKv9GmCuSm94ucQTEC280+XiEc=",
         "owner": "voidlhf",
         "repo": "StarRailGrubThemes",
-        "rev": "c0b1971a4bc2cf4889bfacd96e458a97b0986554",
+        "rev": "de2a250b4fe7e77918058f46fbb2fdf02d05c233",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778767344,
-        "narHash": "sha256-KJutpgkxREVjkYmWortGonNMfFTzTlUlFLPqnqrsqsw=",
+        "lastModified": 1778868483,
+        "narHash": "sha256-bCDqBE3/SPGSYIavgUTz5Ix1LU6/ih8LaDXSoluIN4A=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "a45fc64935e77bdcfdfb1166904db45a813ee4d4",
+        "rev": "cc0d3f63f5310c58cca66b78c1f278b347a42882",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778580735,
-        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {
@@ -1296,11 +1296,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778786436,
-        "narHash": "sha256-tMZKYtpt1KprFa4q0+zgk2mpw3Nf/xT90o+2iBibVMg=",
+        "lastModified": 1778871947,
+        "narHash": "sha256-3q7XAQiMF/mmaBunE7v+CTQpTrLLqDWp7H/SlT8P13M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7eddd3b2a7f73b263245b8bb7ac2563604150f46",
+        "rev": "a1675c821a4eaf0d686886195214b357f9435aa5",
         "type": "github"
       },
       "original": {
@@ -1328,11 +1328,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1778430510,
-        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
         "type": "github"
       },
       "original": {
@@ -1499,11 +1499,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -1531,11 +1531,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778672786,
-        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {
@@ -1553,11 +1553,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778785149,
-        "narHash": "sha256-3YdjBsYMSEAAIN0PKb4Hv4Fp0sZpYL1NtmcEwKowHs4=",
+        "lastModified": 1778870675,
+        "narHash": "sha256-SX5maeSsVW9vuIMCTFwVA9Dw7ntTP6yNG4e0JgeYGmE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a88319fbd475583f2da830ad60effd89c4bd42a3",
+        "rev": "92263e11f194e564552809ff89a5e09e80749639",
         "type": "github"
       },
       "original": {
@@ -1601,11 +1601,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1778784436,
-        "narHash": "sha256-YZtyd/3pdFcei72GtffA0OFjBf6x2cJQ1LEBIAcNMCk=",
+        "lastModified": 1778844551,
+        "narHash": "sha256-FerL73iPCg3FTGMmWyXUxk1qw+YP9bA9KTrsZ8uWZKk=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "8b000238aa8c4727296c456a734f7ad63c2e236e",
+        "rev": "1a482a24375f8adf67336b5badd4762a9169bff5",
         "type": "github"
       },
       "original": {
@@ -1712,11 +1712,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778642276,
-        "narHash": "sha256-bhk4lawR4ZnFhPtamB5WkCyvfgyZmsEUbWfT/3FRxFY=",
+        "lastModified": 1778815121,
+        "narHash": "sha256-xlhD+1NVJbhrUUM2usRHW6iKWTXP2uw2Fo6sWJmLg8g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "77265d2dc1e61b2abfd3b1d6609dbb66fe75e0a5",
+        "rev": "017351829a9356423afd2cca0dde9b63346c8ab3",
         "type": "github"
       },
       "original": {
@@ -1769,11 +1769,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1778540809,
-        "narHash": "sha256-FNXls2QZTcxY0Dem3QtSewnr8vUKMDsTw9m8pLOnhTc=",
+        "lastModified": 1778793632,
+        "narHash": "sha256-HYHD6J64bAWB2iT00lyyTn0wWcb0POtV+nPshYvq6Uc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "83939d7df4c0f1b8ee88cabde112223280a48554",
+        "rev": "e175a8b634e06a1b0635ec3d4db2c72cdc41fd15",
         "type": "github"
       },
       "original": {
@@ -2125,11 +2125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778585655,
-        "narHash": "sha256-yfxy9aTlIgU2Z36H8cJURgYLgjT4qvFeOzoAC/HXcKM=",
+        "lastModified": 1778846616,
+        "narHash": "sha256-cqNwCnEdzUlUgNk9c3bVkXnEfmhzHvHre2Nr2C0sIfo=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "42f41abcef13dc81c85407b57aa1fd1bde46e46c",
+        "rev": "3e3671b5f0e7c60e8f10bdf8667598603203546a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 28 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: dOXY%3D → PYqQ%3D
- chaotic/home-manager: pZOU%3D → zlPs%3D
- chaotic/nixpkgs: HgpE%3D → 0iMM%3D
- chaotic/rust-overlay: RxFY%3D → Lg8g%3D
- firefox: BLcQ%3D → oNA8%3D
- home-manager: VC1A%3D → zlPs%3D
- honkai-railway-grub-theme: cfoE%3D → XiEc%3D
- honkai-railway-grub-theme/nixpkgs: RYbE%3D → wjnA%3D
- hyprland: sqsw%3D → IN4A%3D
- nixpkgs: z0FQ%3D → 0iMM%3D
- nixpkgs-master: bVMg%3D → P13M%3D
- nixpkgs-stable: fi8Q%3D → r4cI%3D
- nur: wHs4%3D → YGmE%3D
- nvf: NMCk%3D → WZKk%3D
- spicetify-nix: nhTc%3D → q6Uc%3D
- zen-browser: XcKM%3D → sIfo%3D
- zen-browser/home-manager: e1RI%3D → U78A%3D

### 📦 System Package Changes
```text
<<< /nix/store/q3g0qvgwcqzj2vq3rb5j1aqxig4qj2vx-nixos-system-loneros-26.05.20260513.eef00df.drv
>>> /nix/store/c33kv7q35x1hcbssp3qbc6hway69djkq-nixos-system-loneros-26.05.20260514.8a1b012.drv
Version changes:
[U.]  #01  SDL2_mixer                  2.8.1 -> 2.8.2
[U.]  #02  cachyos                     7.0.6-1.tar.gz -> 7.0.8-1.tar.gz
[U.]  #03  cpupower                    7.0.6, 7.0.6_fish-completions -> 7.0.8, 7.0.8_fish-completions
[C.]  #04  dnsmasq                     2.92, 2.92rel2 x2, 2.92rel2.tar.xz x2, 2.92.tar.xz -> 2.92rel2 x3, 2.92rel2.tar.xz x3
[U.]  #05  fastfetch                   2.62.1, 2.62.1_fish-completions -> 2.63.1, 2.63.1_fish-completions
[U.]  #06  ghostty-unstable            20260511135427-b0f8276, 20260511135427-b0f8276_fish-completions -> 20260515035026-0071971, 20260515035026-0071971_fish-completions
[U.]  #07  hyprgraphics                0.5.0 -> 0.5.1
[U.]  #08  hyprland                    0.54.3, 0.54.3_fish-completions -> 0.55.1, 0.55.1_fish-completions
[U*]  #09  initrd-linux                7.0.6 -> 7.0.8
[C*]  #10  linux                       6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.6 x2, 7.0.6-modules, 7.0.6-modules-shrunk -> 6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.8 x2, 7.0.8-modules, 7.0.8-modules-shrunk
[C.]  #11  lua                         2.3.4, 2.3.4.tar.gz, 5.2.4 x3, 5.2.4-env, 5.2.4.tar.gz x2, 5.4.7 x2, 5.4.7_fish-completions, 5.4.7.tar.gz -> 2.3.4, 2.3.4.tar.gz, 5.2.4 x3, 5.2.4-env, 5.2.4.tar.gz x2, 5.4.7 x2, 5.4.7_fish-completions, 5.4.7.tar.gz, 5.5.0, 5.5.0.tar.gz
[U.]  #12  material-symbols            4.0.0-unstable-2026-02-06, 4.0.0-unstable-2026-02-06_fish-completions -> 4.0.0-unstable-2026-05-08, 4.0.0-unstable-2026-05-08_fish-completions
[U.]  #13  microcode-intel             20260227 -> 20260512
[U.]  #14  niri-git                    0-unstable-2026-05-10, 0-unstable-2026-05-10_fish-completions, 0-unstable-2026-05-10-vendor, 0-unstable-2026-05-10-vendor-staging -> 0-unstable-2026-05-15, 0-unstable-2026-05-15_fish-completions, 0-unstable-2026-05-15-vendor, 0-unstable-2026-05-15-vendor-staging
[U.]  #15  nixos-system-loneros        26.05.20260513.eef00df -> 26.05.20260514.8a1b012
[U.]  #16  noctalia                    0-unstable-20260514-a9c8801f4, 0-unstable-20260514-a9c8801f4_fish-completions -> 0-unstable-20260515-7db462fda, 0-unstable-20260515-7db462fda_fish-completions
[U.]  #17  noctalia-qs                 0-unstable-20260514-d8327a723 -> 0-unstable-20260515-d8327a723
[C.]  #18  node-v22.22.2.tar.xz        <none> x2 -> <none>
[C.]  #19  nodejs                      22.22.2 x2, 22.22.2-source x2, 22.22.3, 22.22.3-source, 24.14.1 x2, 24.14.1_fish-completions, 24.14.1-source x2 -> 22.22.2, 22.22.2-source, 22.22.3, 22.22.3-source, 24.14.1 x2, 24.14.1_fish-completions, 24.14.1-source x2
[C.]  #20  nodejs-install-executables  <none> x5 -> <none> x4
[C.]  #21  nodejs-slim                 22.22.2, 22.22.3, 24.14.1 x2 -> 22.22.3, 24.14.1 x2
[C.]  #22  npm-config-hook             <none> x5 -> <none> x4
[C.]  #23  npm-install-hook            <none> x5 -> <none> x4
[U.]  #24  nvidia-kernel-modules       595.71.05-7.0.6 -> 595.71.05-7.0.8
[C*]  #25  perl                        5.40.0 x4, 5.40.0.tar.gz x2, 5.42.0 x8, 5.42.0-binlore x2, 5.42.0-env x10, 5.42.0_fish-completions, 5.42.0.tar.gz x3 -> 5.40.0 x4, 5.40.0.tar.gz x2, 5.42.0 x8, 5.42.0-binlore x2, 5.42.0-env x11, 5.42.0_fish-completions, 5.42.0.tar.gz x3
[U.]  #26  plasma-wayland-protocols    1.20.0, 1.20.0.tar.xz -> 1.21.0, 1.21.0.tar.xz
[U.]  #27  rclone                      1.74.0, 1.74.0_fish-completions, 1.74.0-go-modules -> 1.74.1, 1.74.1_fish-completions, 1.74.1-go-modules
[C.]  #28  source                      <none> x2681 -> <none> x2683
[C.]  #29  utils.sh                    <none> x6 -> <none> x7
[U.]  #30  zed-editor                  1.1.7, 1.1.7_fish-completions, 1.1.7-vendor, 1.1.7-vendor-staging -> 1.2.3, 1.2.3_fish-completions, 1.2.3-vendor, 1.2.3-vendor-staging
Added packages:
[A.]  #01  bullet                                          3.25
[A.]  #02  crate-xattr                                     1.6.1.tar.gz
[A.]  #03  d1a4256b3a019117f2bb6cb8c63d6367aaf512e2.patch  <none>
[A.]  #04  efl                                             1.28.1, 1.28.1.tar.xz
[A.]  #05  efl-elua.patch                                  <none>
[A.]  #06  gnome-icon-theme                                3.12.0, 3.12.0.tar.xz
[A.]  #07  humanity-icon-theme                             0.6.16
[A.]  #08  humanity-icon-theme_0.6.16.tar.xz               <none>
[A.]  #09  icon-naming-utils                               0.8.90, 0.8.90.tar.gz
[A.]  #10  mint-x-icons                                    1.7.5
[A.]  #11  setupHook.sh                                    <none>
[A.]  #12  ubuntu-themes                                   24.04
[A.]  #13  ubuntu-themes_24.04.orig.tar.gz                 <none>
[A.]  #14  unit-network.target                             <none>
[A.]  #15  unit-networking-scripted.target                 <none>
[A.]  #16  unit-niri.service                               <none>
[A.]  #17  xattr                                           1.6.1
Closure size: 22785 -> 22804 (299 paths added, 280 paths removed, delta +19, disk usage +114.7KiB).
```