### PR TITLE
Update flake.lock - 2026-05-16T18-46-20Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778867960,
-        "narHash": "sha256-TOQb4wa+hql3X/uLGHsIFaNURVXoe9VJ1kCzmREPYqQ=",
+        "lastModified": 1778950911,
+        "narHash": "sha256-N2TbtAvhetxMHXPP9gWMU0v34Nj+H/76PmCCgdzV1cc=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "a27bfaeab1570c84e6ff4bcc515cfff6606238ad",
+        "rev": "099b03ff77442ac2352e005579ee98d78acffbbd",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778846096,
-        "narHash": "sha256-1Qy1XCFaIpNMDOCXDP/Rsxe9pwXHcBBjzd5KY7foNA8=",
+        "lastModified": 1778932814,
+        "narHash": "sha256-gsZ0kmJf3v/FeKZeK55VKws7W3efUOVQc6r7gEAv7xo=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "f119607765683ae1fb3940b53b0feab06dd70407",
+        "rev": "e00f518f44c2a60ed106e89a086e624a5d077aa3",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778858474,
-        "narHash": "sha256-uOh5fCoxOgdFa50WymuhCwJKuEVv/Eo4VYjK0SgzlPs=",
+        "lastModified": 1778937626,
+        "narHash": "sha256-OzLAT0G96WlT/WWaNdkTvQ7E9ohq9h0xQTdL1oe3gm0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ca77575d39c908de876c10f93704532689df546f",
+        "rev": "d5ece85b6d3d6b5ab5a514b2785fb952b629bfea",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778858474,
-        "narHash": "sha256-uOh5fCoxOgdFa50WymuhCwJKuEVv/Eo4VYjK0SgzlPs=",
+        "lastModified": 1778954430,
+        "narHash": "sha256-oaNyOr05lblaQdtbkbN1wO0b2KLIL2O1LkmwDgdQp4I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ca77575d39c908de876c10f93704532689df546f",
+        "rev": "26aaab785b0bab4af60a2c42b22760fa906ef22a",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778868483,
-        "narHash": "sha256-bCDqBE3/SPGSYIavgUTz5Ix1LU6/ih8LaDXSoluIN4A=",
+        "lastModified": 1778954996,
+        "narHash": "sha256-U/l8nAYLzMsQPriAIdiknypmVidrEqrt11AjbFnq3CI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "cc0d3f63f5310c58cca66b78c1f278b347a42882",
+        "rev": "7d1e481bb8aaf0b56bd91eea24f2fd360eab1986",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778656613,
-        "narHash": "sha256-msfEuGxdU3hMykJKkkKfE+kT1Us/3o4XLjdOaQLyYHA=",
+        "lastModified": 1778879388,
+        "narHash": "sha256-X5DkzTzuHsLQ4P8UATmaaeq5ve0oDvMO3PTsRrY0s9c=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "98800e4d24a3be2d5e9fa47e0dc7c5a1982f99a7",
+        "rev": "8a1ee4335d474c64ddc5d80e3c008ee41b066f4e",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778871947,
-        "narHash": "sha256-3q7XAQiMF/mmaBunE7v+CTQpTrLLqDWp7H/SlT8P13M=",
+        "lastModified": 1778957017,
+        "narHash": "sha256-kt0cOsf8vOmRDmyUKWb1WaTJanPjsUHJyO07OpYvtGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1675c821a4eaf0d686886195214b357f9435aa5",
+        "rev": "54180b9a13f6cb4b1912d2504856ac7bdb80e2a1",
         "type": "github"
       },
       "original": {
@@ -1425,11 +1425,11 @@
     },
     "nixpkgs_14": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778729098,
-        "narHash": "sha256-17SbusskVZng4nwevRqsWNJf27nMG7UczvtgWTUJttg=",
+        "lastModified": 1778843877,
+        "narHash": "sha256-BxYhb8H0aVtiM1kGRt+S49NbsJMUMIHvOXxziE9u0nY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "39ea44cddd5060b8cd413ed5e13c6af61f302283",
+        "rev": "758b562bc257084aef30b8e3efbdd61d292806c3",
         "type": "github"
       },
       "original": {
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778919190,
-        "narHash": "sha256-SyCYGstp9nhjHfQ5cfOazRazEMp3An1KCoK5EHesK54=",
+        "lastModified": 1778956321,
+        "narHash": "sha256-IqbvAIwzMmnjpeYmqAC8gOlAZNc5EKk1OGi5znjEcn4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0ae92a0f85c7c119104ff87a779375ddff99db9",
+        "rev": "c0e79cbddfd64cc0ae0e6a6321d08599382c366f",
         "type": "github"
       },
       "original": {
@@ -1621,11 +1621,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1778844551,
-        "narHash": "sha256-FerL73iPCg3FTGMmWyXUxk1qw+YP9bA9KTrsZ8uWZKk=",
+        "lastModified": 1778881785,
+        "narHash": "sha256-MMAhC3eRS8WV0TF2enKBVRYragTDA3kH9LSZU6tgy5U=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "1a482a24375f8adf67336b5badd4762a9169bff5",
+        "rev": "c27e86f9adbb301fb59eb4666019396e4663c816",
         "type": "github"
       },
       "original": {
@@ -1733,11 +1733,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778815121,
-        "narHash": "sha256-xlhD+1NVJbhrUUM2usRHW6iKWTXP2uw2Fo6sWJmLg8g=",
+        "lastModified": 1778901358,
+        "narHash": "sha256-n35a8GOPs8zi35GXPe4uBz0Y8xseTkQpNgcrq81gPg0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "017351829a9356423afd2cca0dde9b63346c8ab3",
+        "rev": "61ec6a4fc56fe0c2b863f7b3eaba07b6664697d9",
         "type": "github"
       },
       "original": {
@@ -2146,11 +2146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778846616,
-        "narHash": "sha256-cqNwCnEdzUlUgNk9c3bVkXnEfmhzHvHre2Nr2C0sIfo=",
+        "lastModified": 1778919017,
+        "narHash": "sha256-P2+aRay2sPQGVXzNmiD4yYlhy4ytxqBvT4A2OLOvkoU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "3e3671b5f0e7c60e8f10bdf8667598603203546a",
+        "rev": "7c41a80acc12ab012448b84aec90ca9b4bf8b9ac",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778956321,
-        "narHash": "sha256-IqbvAIwzMmnjpeYmqAC8gOlAZNc5EKk1OGi5znjEcn4=",
+        "lastModified": 1778975037,
+        "narHash": "sha256-iycosu6o+g2d6wn+BjtJOzY6a7qLXm/56jv15Z1CNBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c0e79cbddfd64cc0ae0e6a6321d08599382c366f",
+        "rev": "acefc7787b20a437d7c33d0a4b37be214758894d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 29 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: PYqQ%3D → V1cc%3D
- chaotic/home-manager: zlPs%3D → 3gm0%3D
- chaotic/jovian: yYHA%3D → 0s9c%3D
- chaotic/rust-overlay: Lg8g%3D → gPg0%3D
- firefox: oNA8%3D → v7xo%3D
- firefox/nixpkgs: Jttg%3D → u0nY%3D
- home-manager: zlPs%3D → Qp4I%3D
- hyprland: IN4A%3D → q3CI%3D
- nixpkgs-master: P13M%3D → vtGo%3D
- nur: sK54%3D → Ecn4%3D
- nvf: WZKk%3D → gy5U%3D
- tuckr-nix/nixpkgs: wjnA%3D → HASo%3D
- zen-browser: sIfo%3D → vkoU%3D

### 📦 System Package Changes
```text
<<< /nix/store/w202r9bgij6jddf7b1a22b6imaadf2rx-nixos-system-loneros-26.05.20260514.8a1b012.drv
>>> /nix/store/qlv10sdzv6w7a2fqfgvdks7rx4dwn45n-nixos-system-loneros-26.05.20260514.8a1b012.drv
Version changes:
[U.]  #1  ghostty-unstable  20260515035026-0071971, 20260515035026-0071971_fish-completions -> 20260516125727-cf24a48, 20260516125727-cf24a48_fish-completions
[U.]  #2  noctalia          0-unstable-20260515-7db462fda, 0-unstable-20260515-7db462fda_fish-completions -> 0-unstable-20260516-9841a8266, 0-unstable-20260516-9841a8266_fish-completions
[U.]  #3  noctalia-qs       0-unstable-20260515-d8327a723 -> 0-unstable-20260516-d8327a723
[C.]  #4  proton-cachyos    <none>, 11.0-20260429-slr-x86_64_v3.tar.xz -> <none>, 11.0-20260506-slr-x86_64_v3.tar.xz
[U.]  #5  vxwm              0-unstable-2026-05-13, 0-unstable-2026-05-13_fish-completions -> 0-unstable-2026-05-15, 0-unstable-2026-05-15_fish-completions
Closure size: 22815 -> 22815 (58 paths added, 58 paths removed, delta +0, disk usage +0B).
```