### PR TITLE
Update flake.lock - 2026-05-17T18-51-46Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778950911,
-        "narHash": "sha256-N2TbtAvhetxMHXPP9gWMU0v34Nj+H/76PmCCgdzV1cc=",
+        "lastModified": 1779043527,
+        "narHash": "sha256-aKopbVJwOKibOjaSqvAhEbuJCJz4iBP3iRkUSSD7kvA=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "099b03ff77442ac2352e005579ee98d78acffbbd",
+        "rev": "a26b506b20eaf35457b0a1cbe41c62c255bc766b",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1777713215,
-        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
+        "lastModified": 1778958912,
+        "narHash": "sha256-6pvS9rIF9mZRj1ENwu9fDLHeG1JFDTCpRyy6vJhXkTA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
+        "rev": "6e8dc7aa0e65fce67c76e18227a13a7d529f2cdf",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778932814,
-        "narHash": "sha256-gsZ0kmJf3v/FeKZeK55VKws7W3efUOVQc6r7gEAv7xo=",
+        "lastModified": 1779015845,
+        "narHash": "sha256-+zmxT9xRMeji+k0GAEiuhNNIzbAok1jaFTMJe4WIviA=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "e00f518f44c2a60ed106e89a086e624a5d077aa3",
+        "rev": "1449bfb8875ffac32d01d5b9050b5c66e812432d",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778937626,
-        "narHash": "sha256-OzLAT0G96WlT/WWaNdkTvQ7E9ohq9h0xQTdL1oe3gm0=",
+        "lastModified": 1779027260,
+        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5ece85b6d3d6b5ab5a514b2785fb952b629bfea",
+        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778954430,
-        "narHash": "sha256-oaNyOr05lblaQdtbkbN1wO0b2KLIL2O1LkmwDgdQp4I=",
+        "lastModified": 1779027260,
+        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26aaab785b0bab4af60a2c42b22760fa906ef22a",
+        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778954996,
-        "narHash": "sha256-U/l8nAYLzMsQPriAIdiknypmVidrEqrt11AjbFnq3CI=",
+        "lastModified": 1779037148,
+        "narHash": "sha256-1xFi+dLOySAtI76dC0bG/+yA8rnZAH1Xl0s8mpP+PGE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "7d1e481bb8aaf0b56bd91eea24f2fd360eab1986",
+        "rev": "93b83c19f3e4e71fb36ed61a47277e141c09b3f7",
         "type": "github"
       },
       "original": {
@@ -1202,11 +1202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -1239,11 +1239,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778794387,
-        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778957017,
-        "narHash": "sha256-kt0cOsf8vOmRDmyUKWb1WaTJanPjsUHJyO07OpYvtGo=",
+        "lastModified": 1779043676,
+        "narHash": "sha256-c0It/G2tjv2lS4nuimkiKINo4MJJsRCmheA3iqPuO1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54180b9a13f6cb4b1912d2504856ac7bdb80e2a1",
+        "rev": "6acad97b9c2eb385bc4d59d7813f1fa8e8a02ca1",
         "type": "github"
       },
       "original": {
@@ -1396,11 +1396,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-qeRNZKcA0igTdRVnBe6hyo49CqxME92s4G8Sr78ARJw=",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "lastModified": 1778869304,
+        "narHash": "sha256-VdRy3A14M5vIE882DJcaaR+5wrss9Qsg4YNVbr7uj3k=",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre992384.549bd84d6279/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre998534.d233902339c0/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -1503,11 +1503,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778843877,
-        "narHash": "sha256-BxYhb8H0aVtiM1kGRt+S49NbsJMUMIHvOXxziE9u0nY=",
+        "lastModified": 1778930970,
+        "narHash": "sha256-FqqcYr0c5in/HRL5bkRWykAGp/Q10Vj/zUiSr1P8URE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "758b562bc257084aef30b8e3efbdd61d292806c3",
+        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
         "type": "github"
       },
       "original": {
@@ -1551,11 +1551,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778794387,
-        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778975037,
-        "narHash": "sha256-iycosu6o+g2d6wn+BjtJOzY6a7qLXm/56jv15Z1CNBs=",
+        "lastModified": 1779043179,
+        "narHash": "sha256-+6Q9vLYb3Acl83RjVEMXe5ijFtKkpr0jt0An2CpjbqA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "acefc7787b20a437d7c33d0a4b37be214758894d",
+        "rev": "a4c1b63dd0a636657adb77238596f4a2eaa261fa",
         "type": "github"
       },
       "original": {
@@ -1621,11 +1621,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1778881785,
-        "narHash": "sha256-MMAhC3eRS8WV0TF2enKBVRYragTDA3kH9LSZU6tgy5U=",
+        "lastModified": 1779018518,
+        "narHash": "sha256-RUmjcuxbaa8UKsd5rUO5bqDe9YxGBDLXd4tFFBi351E=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "c27e86f9adbb301fb59eb4666019396e4663c816",
+        "rev": "cd45295f9c65ca81f323155660ba83d427bd0154",
         "type": "github"
       },
       "original": {
@@ -1733,11 +1733,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778901358,
-        "narHash": "sha256-n35a8GOPs8zi35GXPe4uBz0Y8xseTkQpNgcrq81gPg0=",
+        "lastModified": 1778987862,
+        "narHash": "sha256-V3qGt9P1eJP/r/1ONablphfGiH0RP4agQhrRANpDYx8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "61ec6a4fc56fe0c2b863f7b3eaba07b6664697d9",
+        "rev": "6f44d8874ac29806c8d5cae42bf8e19ebb5ce0d3",
         "type": "github"
       },
       "original": {
@@ -1790,11 +1790,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1778793632,
-        "narHash": "sha256-HYHD6J64bAWB2iT00lyyTn0wWcb0POtV+nPshYvq6Uc=",
+        "lastModified": 1779000518,
+        "narHash": "sha256-wdtytSnzMe85J/qeXJALMzSLRFTZ1gBHwn81l1PtT8k=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "e175a8b634e06a1b0635ec3d4db2c72cdc41fd15",
+        "rev": "5dde76b38418892ccb3d99e99bed7f8a43ac294c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 29 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: V1cc%3D → 7kvA%3D
- chaotic/home-manager: 3gm0%3D → fY9M%3D
- chaotic/nixpkgs: 0iMM%3D → eBZE%3D
- chaotic/rust-overlay: gPg0%3D → DYx8%3D
- disko: iTTo%3D → XkTA%3D
- firefox: v7xo%3D → IviA%3D
- firefox/nixpkgs: u0nY%3D → 8URE%3D
- home-manager: Qp4I%3D → fY9M%3D
- hyprland: q3CI%3D → BPGE%3D
- nix-index-database: J3Wc%3D → TQDg%3D
- nixpkgs: 0iMM%3D → eBZE%3D
- nixpkgs-master: vtGo%3D → uO1A%3D
- nur: CNBs%3D → jbqA%3D
- nvf: gy5U%3D → 351E%3D
- spicetify-nix: q6Uc%3D → tT8k%3D
- spicetify-nix/nixpkgs: ARJw%3D → uj3k%3D

### 📦 System Package Changes
```text
<<< /nix/store/qlv10sdzv6w7a2fqfgvdks7rx4dwn45n-nixos-system-loneros-26.05.20260514.8a1b012.drv
>>> /nix/store/h8drqljrdybixjh88cimig8mkivw2j0m-nixos-system-loneros-26.05.20260515.d233902.drv
Version changes:
[U.]  #01  cachyos                7.0.8-1.tar.gz -> 7.0.9-1.tar.gz
[U.]  #02  cpupower               7.0.8, 7.0.8_fish-completions -> 7.0.9, 7.0.9_fish-completions
[U.]  #03  curl-impersonate       1.5.5 -> 1.5.6
[U.]  #04  foot                   1.26.1, 1.26.1_fish-completions -> 1.27.0, 1.27.0_fish-completions
[U.]  #05  ghostty-unstable       20260516125727-cf24a48, 20260516125727-cf24a48_fish-completions -> 20260517004218-e90b7c9, 20260517004218-e90b7c9_fish-completions
[U*]  #06  initrd-linux           7.0.8 -> 7.0.9
[U.]  #07  kazumi                 2.1.0, 2.1.0_fish-completions, 2.1.0-package-config.json, 2.1.0-package-config-with-root.json -> 2.1.1, 2.1.1_fish-completions, 2.1.1-package-config.json, 2.1.1-package-config-with-root.json
[C*]  #08  linux                  6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.8 x2, 7.0.8-modules, 7.0.8-modules-shrunk -> 6.5.6.tar.xz, 6.12.76.tar.xz, 6.16.7.tar.xz x2, 6.18.7.tar.xz x3, 7.0.9 x2, 7.0.9-modules, 7.0.9-modules-shrunk
[U.]  #09  nixos-system-loneros   26.05.20260514.8a1b012 -> 26.05.20260515.d233902
[U.]  #10  nvidia-kernel-modules  595.71.05-7.0.8 -> 595.71.05-7.0.9
[U.]  #11  python3.13-ruff        0.15.12 -> 0.15.13
[U.]  #12  python3.13-uv          0.11.13 -> 0.11.14
[U.]  #13  ruff                   0.15.12, 0.15.12-vendor, 0.15.12-vendor-staging -> 0.15.13, 0.15.13-vendor, 0.15.13-vendor-staging
[U.]  #14  scx_full               1.1.0, 1.1.0_fish-completions -> 1.1.1, 1.1.1_fish-completions
[U.]  #15  scx_rustscheds         1.1.0, 1.1.0-vendor, 1.1.0-vendor-staging -> 1.1.1, 1.1.1-vendor, 1.1.1-vendor-staging
[U.]  #16  uv                     0.11.13, 0.11.13-vendor, 0.11.13-vendor-staging -> 0.11.14, 0.11.14-vendor, 0.11.14-vendor-staging
[U.]  #17  zed-editor             1.2.3, 1.2.3_fish-completions, 1.2.3-vendor, 1.2.3-vendor-staging -> 1.2.5, 1.2.5_fish-completions, 1.2.5-vendor, 1.2.5-vendor-staging
Closure size: 22815 -> 22815 (163 paths added, 163 paths removed, delta +0, disk usage +28.4KiB).
```