### PR TITLE
Update flake.lock - 2026-05-18T19-21-57Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779043527,
-        "narHash": "sha256-aKopbVJwOKibOjaSqvAhEbuJCJz4iBP3iRkUSSD7kvA=",
+        "lastModified": 1779127740,
+        "narHash": "sha256-yUbVLY/n4G7zxAxrbIOH3+Ka8anytI616gOQJCGxek8=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "a26b506b20eaf35457b0a1cbe41c62c255bc766b",
+        "rev": "00333159acd441e9dfbc097c6b17f2b0863db094",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1779015845,
-        "narHash": "sha256-+zmxT9xRMeji+k0GAEiuhNNIzbAok1jaFTMJe4WIviA=",
+        "lastModified": 1779117914,
+        "narHash": "sha256-IU+fnbwtBJoKPMy0AMm4yyKv9z6hGofE7wHVUQFTUgQ=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "1449bfb8875ffac32d01d5b9050b5c66e812432d",
+        "rev": "8a088261360d563d374ea52f6c670d8c73b349df",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779027260,
-        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
+        "lastModified": 1779125151,
+        "narHash": "sha256-bPHT0oJAHe5a43lkkSGAiCEg/RBqpwv5xsFrcj+Bog8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
+        "rev": "fab3fd7327a0ac7a1fae5095bf140377704fac7f",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779027260,
-        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
+        "lastModified": 1779125151,
+        "narHash": "sha256-bPHT0oJAHe5a43lkkSGAiCEg/RBqpwv5xsFrcj+Bog8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
+        "rev": "fab3fd7327a0ac7a1fae5095bf140377704fac7f",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1779037148,
-        "narHash": "sha256-1xFi+dLOySAtI76dC0bG/+yA8rnZAH1Xl0s8mpP+PGE=",
+        "lastModified": 1779115357,
+        "narHash": "sha256-FOg5J51dsqKeXC0d2o7x3eMdLDVwRnyMqd1/kupVfwI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "93b83c19f3e4e71fb36ed61a47277e141c09b3f7",
+        "rev": "01ab0474b4ae92db9c25dc0eef6515b99544698f",
         "type": "github"
       },
       "original": {
@@ -1086,11 +1086,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778419596,
-        "narHash": "sha256-ZepYJSEyrVAlyP6wuwcRfRO/cbVJAEQKpsfIzSNQrtc=",
+        "lastModified": 1779025127,
+        "narHash": "sha256-OGTSct+rUI1anMnxvG7KLP9I4LsvCHoVi9yKqcta/xA=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "7a173490ace3bb1b53e310525686d9a34614f4a8",
+        "rev": "eeadc36611ebbecb9d2c8f5bef7049ba60344da9",
         "type": "github"
       },
       "original": {
@@ -1121,11 +1121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778922191,
-        "narHash": "sha256-1tMQG1obLPK8CX0A9lgKH5JPJVY+zLh6ubxC7urt9/c=",
+        "lastModified": 1779126059,
+        "narHash": "sha256-4vTgVFqqmpmmjIadKodDtDJ5X+ISAXI3FG/bKDKjIps=",
         "owner": "lonerOrz",
         "repo": "ncm-desktop",
-        "rev": "fb0da4342b489b7bbe670c0767397491af2dc82e",
+        "rev": "dce7314baaabfd95d3846b611ce32c251051e741",
         "type": "github"
       },
       "original": {
@@ -1271,11 +1271,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1778379128,
-        "narHash": "sha256-+yjPmoKsTqe/FQHriXzIfI0ELuEt3+1LXc0BE8nU/Yc=",
+        "lastModified": 1778984393,
+        "narHash": "sha256-r755Kh5Q0XBTPNuv9rL2rsUJTq8BDhb+lIwRWhl6yYA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e361b0ff94723bc94283566dc2a13a46f07eaf5c",
+        "rev": "0d14a58ab7aa3f513c58ccc9e47e77ffd92be204",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1779043676,
-        "narHash": "sha256-c0It/G2tjv2lS4nuimkiKINo4MJJsRCmheA3iqPuO1A=",
+        "lastModified": 1779131678,
+        "narHash": "sha256-YHCweCiP7TF5DNpyjDGteKBj19qfjsA5l1z61hLHPUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6acad97b9c2eb385bc4d59d7813f1fa8e8a02ca1",
+        "rev": "53ccd94c1e30c0bbf20e8b0d981dd9d05a734d46",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778930970,
-        "narHash": "sha256-FqqcYr0c5in/HRL5bkRWykAGp/Q10Vj/zUiSr1P8URE=",
+        "lastModified": 1779024751,
+        "narHash": "sha256-fIE/HazjcoU/27WI3//uVg5AIntnVo1Q/GjMuBwPuHw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
+        "rev": "3849902757e881ccbf21df80d592e3b94a35131c",
         "type": "github"
       },
       "original": {
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779043179,
-        "narHash": "sha256-+6Q9vLYb3Acl83RjVEMXe5ijFtKkpr0jt0An2CpjbqA=",
+        "lastModified": 1779130239,
+        "narHash": "sha256-s2sddS07zwvLAA+/mnB8sVgJOeH6Q09mpEo0XzvoOuc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4c1b63dd0a636657adb77238596f4a2eaa261fa",
+        "rev": "f0b268869863689654fb869e648a599484b121bf",
         "type": "github"
       },
       "original": {
@@ -1733,11 +1733,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778987862,
-        "narHash": "sha256-V3qGt9P1eJP/r/1ONablphfGiH0RP4agQhrRANpDYx8=",
+        "lastModified": 1779074409,
+        "narHash": "sha256-6aXy8Ga41iLVM8ibddFU1O5+wYWcBGNEfZzZuL91eIc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6f44d8874ac29806c8d5cae42bf8e19ebb5ce0d3",
+        "rev": "2a77b5b1dc952f214e8102acdef1622b68515560",
         "type": "github"
       },
       "original": {
@@ -1753,11 +1753,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777905286,
-        "narHash": "sha256-J8h1LKbK/nDyz/smOK13Yq6mY9ItBgnMDabt5RVML9U=",
+        "lastModified": 1779116225,
+        "narHash": "sha256-o5jyK9JA8qru3Cn4drCo/JN2lizTE9x7jRymwSL6jRk=",
         "owner": "uiriansan",
         "repo": "SilentSDDM",
-        "rev": "8ecdd84438ada68ce4ee7ce70522d4484b103477",
+        "rev": "d7c812cbcb3206c0ea780a84463a7e9a625d1d67",
         "type": "github"
       },
       "original": {
@@ -2146,11 +2146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778919017,
-        "narHash": "sha256-P2+aRay2sPQGVXzNmiD4yYlhy4ytxqBvT4A2OLOvkoU=",
+        "lastModified": 1779093899,
+        "narHash": "sha256-wzHbwUimm45J5r+d4VOi2rrRWwvYimP6OM8BJBIHbYc=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "7c41a80acc12ab012448b84aec90ca9b4bf8b9ac",
+        "rev": "d21282d88c6bd4b3dc692566c5d84de39f7a96c0",
         "type": "github"
       },
       "original": {

--- a/programs/vxwm.nix
+++ b/programs/vxwm.nix
@@ -117,7 +117,7 @@ let
       { MODKEY,                       XK_d,      incnmaster,     {.i = -1 } },
       { MODKEY,                       XK_h,      setmfact,       {.f = -0.05} },
       { MODKEY,                       XK_l,      setmfact,       {.f = +0.05} },
-      { MODKEY,                       XK_Return, zoom,           {0} },
+      { MODKEY,                       XK_Return, swapmaster,           {0} },
       { MODKEY,                       XK_0,      view,           {0} },
       { MODKEY|ShiftMask,             XK_c,      killclient,     {0} },
       { MODKEY,                       XK_t,      setlayout,      {.v = &layouts[0]} },
@@ -190,7 +190,7 @@ let
     #endif
       { ClkLtSymbol,          0,              Button1,        setlayout,      {0} },
       { ClkLtSymbol,          0,              Button3,        setlayout,      {.v = &layouts[2]} },
-      { ClkWinTitle,          0,              Button2,        zoom,           {0} },
+      { ClkWinTitle,          0,              Button2,        swapmaster,           {0} },
       { ClkStatusText,        0,              Button2,        spawn,          {.v = termcmd } },
       { ClkClientWin,         MODKEY,         Button1,        movemouse,      {0} },
       { ClkClientWin,         MODKEY,         Button2,        togglefloating, {0} },


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 29 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: 7kvA%3D → xek8%3D
- chaotic/home-manager: fY9M%3D → Bog8%3D
- chaotic/rust-overlay: DYx8%3D → 1eIc%3D
- firefox: IviA%3D → TUgQ%3D
- firefox/lib-aggregate: Qrtc%3D → xA%3D
- firefox/lib-aggregate/nixpkgs-lib: Yc%3D → 6yYA%3D
- firefox/nixpkgs: 8URE%3D → PuHw%3D
- home-manager: fY9M%3D → Bog8%3D
- hyprland: BPGE%3D → VfwI%3D
- ncm-desktop: c%3D → jIps%3D
- nixpkgs-master: uO1A%3D → HPUQ%3D
- nur: jbqA%3D → oOuc%3D
- silentSDDM: ML9U%3D → 6jRk%3D
- zen-browser: vkoU%3D → HbYc%3D

### 📦 System Package Changes
```text
<<< /nix/store/h8drqljrdybixjh88cimig8mkivw2j0m-nixos-system-loneros-26.05.20260515.d233902.drv
>>> /nix/store/y0gy9hr9q2xf0lp41c5797lkw0q4jgi5-nixos-system-loneros-26.05.20260515.d233902.drv
Version changes:
[U.]  #01  bitwarden-desktop              2026.2.1, 2026.2.1_fish-completions, 2026.2.1-npm-deps, 2026.2.1-vendor, 2026.2.1-vendor-staging -> 2026.3.1, 2026.3.1_fish-completions, 2026.3.1-npm-deps, 2026.3.1-vendor, 2026.3.1-vendor-staging
[C.]  #02  dart                           3.7.2 x2, 3.9.4, 3.10.9, 3.11.4 x2 -> 3.7.2 x2, 3.9.4, 3.10.9, 3.11.4 x3, 3.11.6
[C.]  #03  dart-sass                      1.99.0, 1.99.0-package-config.json, 1.99.0-package-config-with-root.json -> 1.99.0 x2, 1.99.0-package-config.json, 1.99.0-package-config-with-root.json
[C.]  #04  dartsdk-linux-x64-release.zip  <none> x2 -> <none> x3
[C.]  #05  electron                       39.8.9, 40.9.2, 41.3.0 -> 39.8.9, 39.8.10, 40.9.2, 41.3.0
[C.]  #06  electron-unwrapped             39.8.9, 40.9.2, 41.3.0 -> 39.8.9, 39.8.10, 40.9.2, 41.3.0
[C.]  #07  gclient-manifest.json          <none> x4 -> <none> x5
[U.]  #08  ghostty-unstable               20260517004218-e90b7c9, 20260517004218-e90b7c9_fish-completions -> 20260518020309-4b7bf0b, 20260518020309-4b7bf0b_fish-completions
[U.]  #09  noctalia                       0-unstable-20260516-9841a8266, 0-unstable-20260516-9841a8266_fish-completions -> 0-unstable-20260518-f9c3ebd8e, 0-unstable-20260518-f9c3ebd8e_fish-completions
[U.]  #10  noctalia-qs                    0-unstable-20260516-d8327a723 -> 0-unstable-20260518-4116b41cd
[C.]  #11  offline                        <none> x6 -> <none> x7
[C.]  #12  protoc-gen-dart                25.0.0, 25.0.0-package-config.json, 25.0.0-package-config-with-root.json -> 25.0.0 x2, 25.0.0-package-config.json, 25.0.0-package-config-with-root.json
[C.]  #13  source                         <none> x2684 -> <none> x2685
[U.]  #14  vxwm                           0-unstable-2026-05-15, 0-unstable-2026-05-15_fish-completions -> 0-unstable-2026-05-16, 0-unstable-2026-05-16_fish-completions
Added packages:
[A.]  #1  dm469cqnc1a1x6bz3218wrdkfkdriqbn-source  <none>
Removed packages:
[R.]  #1  cmbgk106xs9mvpa3clshiadg5sc6cvxk-source  <none>
Closure size: 22815 -> 22825 (67 paths added, 57 paths removed, delta +10, disk usage +147.0KiB).
```