### PR TITLE
Update flake.lock - 2026-05-19T19-40-34Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779127740,
-        "narHash": "sha256-yUbVLY/n4G7zxAxrbIOH3+Ka8anytI616gOQJCGxek8=",
+        "lastModified": 1779214364,
+        "narHash": "sha256-4YwpPHMD988MVnyWzxMoutxd4WxDsqdmjTXzF0PDuAE=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "00333159acd441e9dfbc097c6b17f2b0863db094",
+        "rev": "265b50fd0dad754a97ffe5cd7498b3beff4fa020",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1778958912,
-        "narHash": "sha256-6pvS9rIF9mZRj1ENwu9fDLHeG1JFDTCpRyy6vJhXkTA=",
+        "lastModified": 1779135526,
+        "narHash": "sha256-glCununz6lmaK5fs2X946HA3EkNxB2JagdAAvInuRYU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "6e8dc7aa0e65fce67c76e18227a13a7d529f2cdf",
+        "rev": "d405a179887d52b24c0ddd31e09a150bd1f66779",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1779117914,
-        "narHash": "sha256-IU+fnbwtBJoKPMy0AMm4yyKv9z6hGofE7wHVUQFTUgQ=",
+        "lastModified": 1779207536,
+        "narHash": "sha256-G7rQ898y4b4kQacsjryTlWWdgGIIQYGms4Naq+30lGI=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "8a088261360d563d374ea52f6c670d8c73b349df",
+        "rev": "ca17769de86d4095a78227f73997d02ab3b9527b",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779125151,
-        "narHash": "sha256-bPHT0oJAHe5a43lkkSGAiCEg/RBqpwv5xsFrcj+Bog8=",
+        "lastModified": 1779213149,
+        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fab3fd7327a0ac7a1fae5095bf140377704fac7f",
+        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779125151,
-        "narHash": "sha256-bPHT0oJAHe5a43lkkSGAiCEg/RBqpwv5xsFrcj+Bog8=",
+        "lastModified": 1779213149,
+        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fab3fd7327a0ac7a1fae5095bf140377704fac7f",
+        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1779115357,
-        "narHash": "sha256-FOg5J51dsqKeXC0d2o7x3eMdLDVwRnyMqd1/kupVfwI=",
+        "lastModified": 1779190425,
+        "narHash": "sha256-C0hPhLeo3ztBXYSnpYarYjw6HDvlgZRnNyFfG5PoaVI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "01ab0474b4ae92db9c25dc0eef6515b99544698f",
+        "rev": "203a121537d0868bd4d8258b58861ca970483157",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1779131678,
-        "narHash": "sha256-YHCweCiP7TF5DNpyjDGteKBj19qfjsA5l1z61hLHPUQ=",
+        "lastModified": 1779217787,
+        "narHash": "sha256-TJkFauCqX8VX1SGOcibdCUHAapfRV14+/YhJZw8or4U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53ccd94c1e30c0bbf20e8b0d981dd9d05a734d46",
+        "rev": "89bd4efcc1560dd8ee8e4562f3cf768b23be8513",
         "type": "github"
       },
       "original": {
@@ -1348,11 +1348,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1779024751,
-        "narHash": "sha256-fIE/HazjcoU/27WI3//uVg5AIntnVo1Q/GjMuBwPuHw=",
+        "lastModified": 1779142197,
+        "narHash": "sha256-Fypu3KtYQ+ZXL91CZIGqS3ZKwrMH6GOSPCtJ07W3ecU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3849902757e881ccbf21df80d592e3b94a35131c",
+        "rev": "d4d6b67b138722feb847a75760a430943c33f4ef",
         "type": "github"
       },
       "original": {
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779130239,
-        "narHash": "sha256-s2sddS07zwvLAA+/mnB8sVgJOeH6Q09mpEo0XzvoOuc=",
+        "lastModified": 1779218989,
+        "narHash": "sha256-iAUqjUcf5tVUAe2ID8N0IYg/TF5ipftkbqgm1mwWTvo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f0b268869863689654fb869e648a599484b121bf",
+        "rev": "ce1e0ad96c4f9c7db45f01e4f484651ac63ab9b1",
         "type": "github"
       },
       "original": {
@@ -1733,11 +1733,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779074409,
-        "narHash": "sha256-6aXy8Ga41iLVM8ibddFU1O5+wYWcBGNEfZzZuL91eIc=",
+        "lastModified": 1779160702,
+        "narHash": "sha256-frUihZLlBLdcFN95mq5QiQmxF2M16nxtmw1GH4rhZmg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2a77b5b1dc952f214e8102acdef1622b68515560",
+        "rev": "8cd592658d4448c57326aaa819e1c2f91086eb40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 29 inputs (excluding: lix, lix-module)

✨ Update details:
- chaotic: xek8%3D → DuAE%3D
- chaotic/home-manager: Bog8%3D → yS3E%3D
- chaotic/rust-overlay: 1eIc%3D → hZmg%3D
- disko: XkTA%3D → uRYU%3D
- firefox: TUgQ%3D → 0lGI%3D
- firefox/nixpkgs: PuHw%3D → 3ecU%3D
- home-manager: Bog8%3D → yS3E%3D
- hyprland: VfwI%3D → oaVI%3D
- nixpkgs-master: HPUQ%3D → or4U%3D
- nixpkgs-stable: r4cI%3D → DNNg%3D
- nur: oOuc%3D → WTvo%3D

### 📦 System Package Changes
```text
<<< /nix/store/fgalv9aiplgakmpriiazqb43qf7660gl-nixos-system-loneros-26.05.20260515.d233902.drv
>>> /nix/store/10vddyvnw8bkyqfb97vh46wyjw7d22w2-nixos-system-loneros-26.05.20260515.d233902.drv
Version changes:
[C.]  #1  firefox                        140.9.0esr.source.tar.xz x2, 152.0a1.en-US.linux-x86_64.tar.xz -> 140.9.0esr.source.tar.xz x2, 153.0a1.en-US.linux-x86_64.tar.xz
[U.]  #2  firefox-nightly-bin            152.0a1, 152.0a1_fish-completions -> 153.0a1, 153.0a1_fish-completions
[U.]  #3  firefox-nightly-bin-unwrapped  152.0a1 -> 153.0a1
[U.]  #4  ghostty-themes-release         20260427-153600-5e4d1de.tgz -> 20260511-160054-2671288.tgz
[U.]  #5  ghostty-unstable               20260518020309-4b7bf0b, 20260518020309-4b7bf0b_fish-completions -> 20260519161109-8150b5b, 20260519161109-8150b5b_fish-completions
[U.]  #6  noctalia                       0-unstable-20260518-f9c3ebd8e, 0-unstable-20260518-f9c3ebd8e_fish-completions -> 0-unstable-20260519-3f6d5bb1c, 0-unstable-20260519-3f6d5bb1c_fish-completions
[U.]  #7  noctalia-qs                    0-unstable-20260518-4116b41cd -> 0-unstable-20260519-4116b41cd
Closure size: 22825 -> 22825 (34 paths added, 34 paths removed, delta +0, disk usage +24B).
```