### PR TITLE
Update flake.lock - 2026-05-23T18-53-17Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779387907,
-        "narHash": "sha256-0vXCjdTK3iRt41/2iuIbOiAiDZ2Ldw3qGDiwMSDbGLg=",
+        "lastModified": 1779561381,
+        "narHash": "sha256-3MT9qB/i34B5JLTT7Tphjft8BypF6pevULbF0EnG3HQ=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "f5abc97d7cf8f5764d0f245949b6f8176c593c86",
+        "rev": "57fb142e7609725fe13198d9cc184515412f4cc1",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1779469831,
-        "narHash": "sha256-BcufawoVf4HAfF3FSJ2CxCwQKk9o0q6+zztA1tipsJM=",
+        "lastModified": 1779542390,
+        "narHash": "sha256-4sXg8XsNR7YN5u6aFCnt2zde80//ZpXHoqXw8ymDWqE=",
         "owner": "nix-community",
         "repo": "flake-firefox-nightly",
-        "rev": "ab9b079c6bc1a390eb16cc89c40a3b8d2d15cd0e",
+        "rev": "e30ef2ef6b862ad390ee851ade6c857a9d359f4c",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779336838,
-        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
+        "lastModified": 1779507042,
+        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
+        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779336838,
-        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
+        "lastModified": 1779507042,
+        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
+        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1779475317,
-        "narHash": "sha256-AIjzDzXB3vQjlcY3/m1UJxCoWW7aSyibSGB4l2J25Pw=",
+        "lastModified": 1779538437,
+        "narHash": "sha256-QTVm1lfienmW8sjcdnqwpffgMG8QPc+hBXUmZjQJOYs=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "ab567fc880f20ba73eab1b201a1c9bbcb66d6978",
+        "rev": "55b404b0a13518da3252cb176cf4a5a6ce9df2be",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779349451,
-        "narHash": "sha256-+xv7+hV4Ow51QzlP3PFQsDPB5bMhLMLfrgKTJX3jNsM=",
+        "lastModified": 1779525206,
+        "narHash": "sha256-5sr/1CIdf1qu6SCeM6qkiBCuD3s3P8TugUY4JKQ6kUI=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "885e391f4c0f676417c86706d132e35e0c785bc1",
+        "rev": "4b81cbddc037e480c2f3c20dee1a6457c6bb99b8",
         "type": "github"
       },
       "original": {
@@ -1239,11 +1239,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779259093,
-        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
+        "lastModified": 1779475168,
+        "narHash": "sha256-gm3D4FF9EcZlXK/ZnsC6IYzpEQplOoT+LPTurzOPyrk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
+        "rev": "a0991c886dc83e6e9de01d5266e4842985b1850e",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1779477115,
-        "narHash": "sha256-M3gSVWwN84DRTKFBLsb8NNaUOKJBMKOqRpVi5J4lcR8=",
+        "lastModified": 1779561355,
+        "narHash": "sha256-HrMbEBJUdOIQ8m5HMjOWa3OaSMo3VWmkN+gHP0kRVmw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c16b8a397ef6c9b963e6c9a200a1646c73437a6e",
+        "rev": "f9188aa83c426496b2471fe23c000033e189f26a",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1779436535,
-        "narHash": "sha256-jJ8YPw+bnLy1c8oI0hO4NKvbCQOt9V1aSUzhpLPs3Cw=",
+        "lastModified": 1779522599,
+        "narHash": "sha256-3F5IRy9EUlVYH9PYuBav+VVBSJsFK+XztqQ7AJU/I3M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d04de155b837ea2ba199ec83851b9dbffe57af08",
+        "rev": "492bd1f77a7ccf2e2858b3935fe209d3b31f9159",
         "type": "github"
       },
       "original": {
@@ -1551,11 +1551,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1779414690,
-        "narHash": "sha256-gOTcX/9MZVMUE0Xvb4IEcv+0TQJkZFNEnL757ljU360=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779477403,
-        "narHash": "sha256-RzYg6HYaC1qXv88s0gAeu85RCXVXiHmVAnAklMrFo4g=",
+        "lastModified": 1779557940,
+        "narHash": "sha256-jO9hENOayABpVCqVImZ5u2OH7EKc2B+Cvrv7fvK3xqc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e462857c9d071c696f833c97fab42df341f2601c",
+        "rev": "4a1b78c25e3be6c3053722f6fa2cc2097761bcce",
         "type": "github"
       },
       "original": {
@@ -1733,11 +1733,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779333539,
-        "narHash": "sha256-lpmN2lrBDZDPjov2cbD3bOOJsI0fkKolKXasYPCqSys=",
+        "lastModified": 1779506148,
+        "narHash": "sha256-OffE5yuMrSW71zIJNLvtl9MCO6WTAHEjlFPUCvkd/QM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "672fa5fc5608d5cd82286a6f69aaf84a40b4fe41",
+        "rev": "d9973e2ab49747fada06ebbe26cda27eb0220cf1",
         "type": "github"
       },
       "original": {

--- a/programs/default.nix
+++ b/programs/default.nix
@@ -14,6 +14,8 @@ in
       "virtualbox"
       "virt-manager"
       "fabric"
+
+      "vxwm"
     ];
   };
 }

--- a/programs/vxwm.nix
+++ b/programs/vxwm.nix
@@ -14,39 +14,61 @@ let
     static const unsigned int snap      = 32;
     static const int showbar            = 1;
     static const int topbar             = 1;
-    static const char *fonts[]          = { "monospace:size=10" };
+
+    static const char *fonts[]          = {
+      "monospace:size=10"
+    };
+
     static const char dmenufont[]       = "monospace:size=10";
 
-    static MAYBE_CONST char normbgcolor[]           = "#222222";
-    static MAYBE_CONST char normbordercolor[]       = "#444444";
-    static MAYBE_CONST char normfgcolor[]           = "#bbbbbb";
-    static MAYBE_CONST char selfgcolor[]            = "#eeeeee";
-    static MAYBE_CONST char selbordercolor[]        = "#005577";
-    static MAYBE_CONST char selbgcolor[]            = "#005577";
+    static MAYBE_CONST char normbgcolor[]    = "#222222";
+    static MAYBE_CONST char normbordercolor[] = "#444444";
+    static MAYBE_CONST char normfgcolor[]    = "#bbbbbb";
+
+    static MAYBE_CONST char selfgcolor[]     = "#eeeeee";
+    static MAYBE_CONST char selbordercolor[] = "#005577";
+    static MAYBE_CONST char selbgcolor[]     = "#005577";
+
     static MAYBE_CONST char *colors[][3] = {
-           /*               fg           bg           border   */
-           [SchemeNorm] = { normfgcolor, normbgcolor, normbordercolor },
-           [SchemeSel]  = { selfgcolor,  selbgcolor,  selbordercolor  },
+      /*               fg           bg           border */
+      [SchemeNorm] = {
+        normfgcolor,
+        normbgcolor,
+        normbordercolor
+      },
+
+      [SchemeSel] = {
+        selfgcolor,
+        selbgcolor,
+        selbordercolor
+      },
     };
 
     #define CENTER_NEW_FLOATING_WINDOWS 1
     #define NEW_FLOATING_WINDOWS_APPEAR_UNDER_CURSOR 0
 
     #if GAPS
-    static const unsigned int gappx = 10;  // 窗口间距
+    static const unsigned int gappx = 10;
     #endif
 
     #if BAR_HEIGHT
-    static const int user_bh = 24;  // 状态栏高度
+    static const int user_bh = 24;
     #endif
 
     #if BAR_PADDING
-    static const int vertpad = 10;
-    static const int sidepad = 10;
+    static const int top_vertpad    = 10;
+    static const int bottom_vertpad = 10;
+
+    static const int left_sidepad   = 10;
+    static const int right_sidepad  = 10;
     #endif
 
     /* tagging */
-    static const char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+    static const char *tags[] = {
+      "1", "2", "3",
+      "4", "5", "6",
+      "7", "8", "9"
+    };
 
     #if INFINITE_TAGS
     #define MOVE_CANVAS_STEP 120
@@ -69,9 +91,9 @@ let
     #endif
 
     static const Rule rules[] = {
-      /* class      instance    title       tags mask     isfloating   monitor */
-      { "Gimp",     NULL,       NULL,       0,            1,           -1 },
-      { "Firefox",  NULL,       NULL,       1 << 8,       0,           -1 },
+      /* class      instance  title  tags mask  isfloating  monitor */
+      { "Gimp",    NULL, NULL, 0,       1, -1 },
+      { "Firefox", NULL, NULL, 1 << 8,  0, -1 },
     };
 
     /* layout(s) */
@@ -79,137 +101,128 @@ let
     static const int nmaster     = 1;
     static const int resizehints = 1;
     static const int lockfullscreen = 1;
+
     #if LOCK_MOVE_RESIZE_REFRESH_RATE
     static const int refreshrate = 144;
     #endif
+
     static const Layout layouts[] = {
-      /* symbol     arrange function */
-      { "><>",      NULL },
-      { "[]=",      tile },
-      { "[M]",      monocle },
+      /* symbol arrange function */
+      { "><>", NULL },
+      { "[]=", tile },
+      { "[M]", monocle },
     };
 
     /* key definitions */
-    #define MODKEY Mod1Mask  // 改用 Alt 键！
+    #define MODKEY Mod1Mask
     #define ALTERNATE_MODKEY Mod4Mask
 
     #define TAGKEYS(KEY,TAG) \
-      { MODKEY,                       KEY,      view,           {.ui = 1 << TAG} }, \
-      { MODKEY|ControlMask,           KEY,      toggleview,     {.ui = 1 << TAG} }, \
-      { ALTERNATE_MODKEY,             KEY,      tag,            {.ui = 1 << TAG} }, \
-      { MODKEY|ControlMask|ShiftMask, KEY,      toggletag,      {.ui = 1 << TAG} },
+      { MODKEY,                       KEY, view,       {.ui = 1 << TAG} }, \
+      { MODKEY|ControlMask,           KEY, toggleview, {.ui = 1 << TAG} }, \
+      { ALTERNATE_MODKEY,             KEY, tag,        {.ui = 1 << TAG} }, \
+      { MODKEY|ControlMask|ShiftMask, KEY, toggletag,  {.ui = 1 << TAG} },
 
-    #define SHCMD(cmd) { .v = (const char*[]){ "/bin/sh", "-c", cmd, NULL } }
+    #define SHCMD(cmd) \
+      { .v = (const char*[]){ "/bin/sh", "-c", cmd, NULL } }
 
     /* commands */
     static char dmenumon[2] = "0";
-    static const char *dmenucmd[] = { "rofi", "-show", "drun", NULL };  // 用 rofi 替代 dmenu
-    static const char *termcmd[]  = { "ghostty", NULL };  // 用 ghostty 替代 st
+
+    static const char *dmenucmd[] = {
+      "rofi",
+      "-show",
+      "drun",
+      NULL
+    };
+
+    static const char *termcmd[] = {
+      "ghostty",
+      NULL
+    };
 
     static const Key keys[] = {
-      /* modifier                     key        function        argument */
-      { MODKEY,                       XK_p,      spawn,          {.v = dmenucmd } },
-      { MODKEY|ShiftMask,             XK_Return, spawn,          {.v = termcmd } },
-      { MODKEY,                       XK_b,      togglebar,      {0} },
-      { MODKEY,                       XK_j,      focusstack,     {.i = +1 } },
-      { MODKEY,                       XK_k,      focusstack,     {.i = -1 } },
-      { MODKEY,                       XK_i,      incnmaster,     {.i = +1 } },
-      { MODKEY,                       XK_d,      incnmaster,     {.i = -1 } },
-      { MODKEY,                       XK_h,      setmfact,       {.f = -0.05} },
-      { MODKEY,                       XK_l,      setmfact,       {.f = +0.05} },
-      { MODKEY,                       XK_Return, swapmaster,           {0} },
-      { MODKEY,                       XK_0,      view,           {0} },
-      { MODKEY|ShiftMask,             XK_c,      killclient,     {0} },
-      { MODKEY,                       XK_t,      setlayout,      {.v = &layouts[0]} },
-      { MODKEY,                       XK_f,      setlayout,      {.v = &layouts[1]} },
-      { MODKEY,                       XK_m,      setlayout,      {.v = &layouts[2]} },
-      { MODKEY,                       XK_space,  setlayout,      {0} },
-      { MODKEY|ShiftMask,             XK_space,  togglefloating, {0} },
-      { MODKEY,                       XK_Tab,    view,           {.ui = ~0 } },
-      { MODKEY|ShiftMask,             XK_0,      tag,            {.ui = ~0 } },
-      { MODKEY,                       XK_comma,  focusmon,       {.i = -1 } },
-      { MODKEY,                       XK_period, focusmon,       {.i = +1 } },
-      { MODKEY|ShiftMask,             XK_comma,  tagmon,         {.i = -1 } },
-      { MODKEY|ShiftMask,             XK_period, tagmon,         {.i = +1 } },
-      TAGKEYS(                        XK_1,                      0)
-      TAGKEYS(                        XK_2,                      1)
-      TAGKEYS(                        XK_3,                      2)
-      TAGKEYS(                        XK_4,                      3)
-      TAGKEYS(                        XK_5,                      4)
-      TAGKEYS(                        XK_6,                      5)
-      TAGKEYS(                        XK_7,                      6)
-      TAGKEYS(                        XK_8,                      7)
-      TAGKEYS(                        XK_9,                      8)
-      { MODKEY|ShiftMask,             XK_q,      quit,           {0} },
-    #if XRDB
-      { MODKEY,                       XK_F5,     xrdb,           {.v = NULL } },
-    #endif
-    #if FULLSCREEN
-      { MODKEY|ShiftMask,             XK_f,      togglefullscr,  {0} },
-    #endif
-    #if ENHANCED_TOGGLE_FLOATING
-      { MODKEY,                       XK_q,      enhancedtogglefloating, {0} },
-    #endif
-    #if GAPS
-      { MODKEY,                       XK_minus,  setgaps,        {.i = -1 } },
-      { MODKEY,                       XK_equal,  setgaps,        {.i = +1 } },
-      { MODKEY|ShiftMask,             XK_equal,  setgaps,        {.i = 0  } },
-    #endif
-    #if MOVE_RESIZE_WITH_KEYBOARD
-      { MODKEY,                       XK_Down,   moveresize,     {.v = (int []){ 0, MOVE_WITH_KEYBOARD_STEP, 0, 0 }}},
-      { MODKEY,                       XK_Up,     moveresize,     {.v = (int []){ 0, -MOVE_WITH_KEYBOARD_STEP, 0, 0 }}},
-      { MODKEY,                       XK_Right,  moveresize,     {.v = (int []){ MOVE_WITH_KEYBOARD_STEP, 0, 0, 0 }}},
-      { MODKEY,                       XK_Left,   moveresize,     {.v = (int []){ -MOVE_WITH_KEYBOARD_STEP, 0, 0, 0 }}},
-      { MODKEY|ControlMask,           XK_Down,   moveresize,     {.v = (int []){ 0, 0, 0, RESIZE_WITH_KEYBOARD_STEP }}},
-      { MODKEY|ControlMask,           XK_Up,     moveresize,     {.v = (int []){ 0, 0, 0, -RESIZE_WITH_KEYBOARD_STEP }}},
-      { MODKEY|ControlMask,           XK_Right,  moveresize,     {.v = (int []){ 0, 0, RESIZE_WITH_KEYBOARD_STEP, 0 }}},
-      { MODKEY|ControlMask,           XK_Left,   moveresize,     {.v = (int []){ 0, 0, -RESIZE_WITH_KEYBOARD_STEP, 0 }}},
-    #endif
-    #if INFINITE_TAGS
-      { MODKEY,                       XK_r,      homecanvas,     {0} },
-      { MODKEY|ShiftMask,             XK_Left,   movecanvas,     {.i = 0} },
-      { MODKEY|ShiftMask,             XK_Right,  movecanvas,     {.i = 1} },
-      { MODKEY|ShiftMask,             XK_Up,     movecanvas,     {.i = 2} },
-      { MODKEY|ShiftMask,             XK_Down,   movecanvas,     {.i = 3} },
-      { MODKEY|ShiftMask,             XK_d,      centerwindow,   {0} },
-    #endif
-    #if DIRECTIONAL_FOCUS
-      { ALTERNATE_MODKEY,             XK_Left,   focusdir,       {.i = 0 } },
-      { ALTERNATE_MODKEY,             XK_Right,  focusdir,       {.i = 1 } },
-      { ALTERNATE_MODKEY,             XK_Up,     focusdir,       {.i = 2 } },
-      { ALTERNATE_MODKEY,             XK_Down,   focusdir,       {.i = 3 } },
-    #endif
+      /* modifier                     key           function        argument */
+
+      { MODKEY,                       XK_p,         spawn,          {.v = dmenucmd } },
+      { MODKEY|ShiftMask,             XK_Return,    spawn,          {.v = termcmd } },
+
+      { MODKEY,                       XK_b,         togglebar,      {0} },
+
+      { MODKEY,                       XK_j,         focusstack,     {.i = +1 } },
+      { MODKEY,                       XK_k,         focusstack,     {.i = -1 } },
+
+      { MODKEY,                       XK_i,         incnmaster,     {.i = +1 } },
+      { MODKEY,                       XK_d,         incnmaster,     {.i = -1 } },
+
+      { MODKEY,                       XK_h,         setmfact,       {.f = -0.05} },
+      { MODKEY,                       XK_l,         setmfact,       {.f = +0.05} },
+
+      { MODKEY,                       XK_Return,    swapmaster,     {0} },
+
+      { MODKEY,                       XK_0,         view,           {0} },
+
+      { MODKEY|ShiftMask,             XK_c,         killclient,     {0} },
+
+      { MODKEY,                       XK_t,         setlayout,      {.v = &layouts[0]} },
+      { MODKEY,                       XK_f,         setlayout,      {.v = &layouts[1]} },
+      { MODKEY,                       XK_m,         setlayout,      {.v = &layouts[2]} },
+
+      { MODKEY,                       XK_space,     setlayout,      {0} },
+
+      { MODKEY|ShiftMask,             XK_space,     togglefloating, {0} },
+
+      { MODKEY,                       XK_Tab,       view,           {.ui = ~0 } },
+
+      { MODKEY|ShiftMask,             XK_0,         tag,            {.ui = ~0 } },
+
+      { MODKEY,                       XK_comma,     focusmon,       {.i = -1 } },
+      { MODKEY,                       XK_period,    focusmon,       {.i = +1 } },
+
+      { MODKEY|ShiftMask,             XK_comma,     tagmon,         {.i = -1 } },
+      { MODKEY|ShiftMask,             XK_period,    tagmon,         {.i = +1 } },
+
+      TAGKEYS(XK_1, 0)
+      TAGKEYS(XK_2, 1)
+      TAGKEYS(XK_3, 2)
+      TAGKEYS(XK_4, 3)
+      TAGKEYS(XK_5, 4)
+      TAGKEYS(XK_6, 5)
+      TAGKEYS(XK_7, 6)
+      TAGKEYS(XK_8, 7)
+      TAGKEYS(XK_9, 8)
+
+      { MODKEY|ShiftMask,             XK_q,         quit,           {0} },
     };
 
     /* button definitions */
     static const Button buttons[] = {
-      /* click                event mask      button          function        argument */
+
     #if INFINITE_TAGS
-      { ClkRootWin,      MODKEY|ShiftMask,         Button1,        movecanvasmouse,     {.f = 1.5 } },
-      { ClkClientWin,    MODKEY|ShiftMask,         Button1,        movecanvasmouse,     {.f = 1.5 } },
+      { ClkRootWin, MODKEY|ShiftMask, Button1,
+        movecanvasmouse, {.f = 1.5 } },
+
+      { ClkClientWin, MODKEY|ShiftMask, Button1,
+        movecanvasmouse, {.f = 1.5 } },
     #endif
-      { ClkLtSymbol,          0,              Button1,        setlayout,      {0} },
-      { ClkLtSymbol,          0,              Button3,        setlayout,      {.v = &layouts[2]} },
-      { ClkWinTitle,          0,              Button2,        swapmaster,           {0} },
-      { ClkStatusText,        0,              Button2,        spawn,          {.v = termcmd } },
-      { ClkClientWin,         MODKEY,         Button1,        movemouse,      {0} },
-      { ClkClientWin,         MODKEY,         Button2,        togglefloating, {0} },
-      { ClkClientWin,         MODKEY,         Button3,        resizemouse,    {0} },
-      { ClkTagBar,            0,              Button1,        view,           {0} },
-      { ClkTagBar,            0,              Button3,        toggleview,     {0} },
-      { ClkTagBar,            MODKEY,         Button1,        tag,            {0} },
-      { ClkTagBar,            MODKEY,         Button3,        toggletag,      {0} },
+
+      { ClkLtSymbol,   0, Button1, setlayout,      {0} },
+      { ClkLtSymbol,   0, Button3, setlayout,      {.v = &layouts[2]} },
+
+      { ClkWinTitle,   0, Button2, swapmaster,     {0} },
+
+      { ClkStatusText, 0, Button2, spawn,          {.v = termcmd } },
+
+      { ClkClientWin,  MODKEY, Button1, movemouse,      {0} },
+      { ClkClientWin,  MODKEY, Button2, togglefloating, {0} },
+      { ClkClientWin,  MODKEY, Button3, resizemouse,    {0} },
+
+      { ClkTagBar, 0,       Button1, view,       {0} },
+      { ClkTagBar, 0,       Button3, toggleview, {0} },
+
+      { ClkTagBar, MODKEY, Button1, tag,       {0} },
+      { ClkTagBar, MODKEY, Button3, toggletag, {0} },
     };
-  '';
-
-  # === 2. 自定义 modules.def.h（通过 patch 方式修改） ===
-  # 如果你想关闭某些模块，可以用 sed 在 postPatch 里处理
-  disableModulesPatch = ''
-    # 示例：关闭自动启动模块
-    sed -i 's/#define AUTOSTART 1/#define AUTOSTART 0/' modules.def.h
-
-    # 示例：关闭光标扭曲模块
-    sed -i 's/#define WARP_TO_CLIENT 1/#define WARP_TO_CLIENT 0/' modules.def.h
   '';
 
   vxwmCustom = pkgs.nur.repos.lonerOrz.vxwm.override {
@@ -217,15 +230,14 @@ let
     patches = [ ];
     extraLibs = [ ];
   };
+
 in
 {
   services.xserver = {
     enable = true;
 
-    # 使用 NVIDIA 驱动
     videoDrivers = [ "nvidia" ];
 
-    # 核心：强制合成管线（解决拖影/撕裂关键）
     deviceSection = ''
       Option "ForceFullCompositionPipeline" "true"
       Option "TripleBuffer" "true"
@@ -236,6 +248,7 @@ in
     windowManager.session = [
       {
         name = "vxwm";
+
         start = ''
           ${vxwmCustom}/bin/vxwm &
           waitPID=$!


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 29 inputs (excluding: lix-module, lix)

✨ Update details:
- chaotic: bGLg%3D → G3HQ%3D
- chaotic/home-manager: 2Bd8%3D → 7lxQ%3D
- chaotic/jovian: jNsM%3D → 6kUI%3D
- chaotic/nixpkgs: Onxc%3D → Pyrk%3D
- chaotic/rust-overlay: qSys%3D → QM%3D
- firefox: psJM%3D → DWqE%3D
- firefox/nixpkgs: s3Cw%3D → I3M%3D
- home-manager: 2Bd8%3D → 7lxQ%3D
- hyprland: 25Pw%3D → JOYs%3D
- nixpkgs: U360%3D → iBO8%3D
- nixpkgs-master: lcR8%3D → RVmw%3D
- nur: Fo4g%3D → 3xqc%3D
