### PR TITLE
Update flake.lock - 2026-05-28T22-23-06Z

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -84,18 +84,90 @@ jobs:
 
       - name: Build Path
         id: build
+        continue-on-error: true
         run: |
           echo "Building ${{ matrix.package.name }}..."
           nix build --no-link --impure --expr 'let flake = builtins.getFlake (toString ./.); pkgs = flake.nixosConfigurations.loneros.config.environment.systemPackages; target = builtins.filter (p: p ? drvPath && p.drvPath == "${{ matrix.package.drv }}") pkgs; in if target == [] then throw "Package not found" else builtins.head target' --print-build-logs
 
-      - name: Log success to summary
-        if: success()
+      - name: Generate status report
+        if: always()
         run: |
-          echo "✅ **Successfully built and pushed**: \`${{ matrix.package.name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "Store path deriver: \`${{ matrix.package.drv }}\`" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.build.outcome }}" == "success" ]; then
+            SUCCESSFUL="true"
+          else
+            SUCCESSFUL="false"
+          fi
 
-      - name: Log failure to summary
-        if: failure()
+          jq -n \
+            --arg name "${{ matrix.package.name }}" \
+            --arg drv "${{ matrix.package.drv }}" \
+            --arg successful "$SUCCESSFUL" \
+            '{"name": $name, "drv": $drv, "successful": ($successful | test("true"))}' > "report_${{ matrix.package.name }}.json"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-report-${{ matrix.package.name }}
+          path: report_${{ matrix.package.name }}.json
+
+  summary:
+    name: Build Summary
+    runs-on: ubuntu-latest
+    needs: [build-matrix]
+    if: always()
+    steps:
+      - name: Download all reports
+        uses: actions/download-artifact@v6
+        with:
+          pattern: build-report-*
+          merge-multiple: true
+
+      - name: Generate combined step summary
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "❌ **Failed to build**: \`${{ matrix.package.name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "Please check the log of job: **Build ${{ matrix.package.name }}**" >> $GITHUB_STEP_SUMMARY
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name != null) | {
+              key: .name,
+              value: (
+                .html_url + (
+                  [ .steps[] | select(.name == "Build Path") | .number ] | first | if . != null then "#step:" + (. | toString) + ":1" else "" end
+                )
+              )
+            }' | jq -s 'from_entries' > job_urls.json
+
+          {
+            echo "### Cachix Build Results"
+            echo ""
+            echo "| Package | Status | Derivation |"
+            echo "| :--- | :--- | :--- |"
+
+            for f in report_*.json; do
+              if [ ! -f "$f" ]; then continue; fi
+              NAME=$(jq -r '.name' "$f")
+              DRV=$(jq -r '.drv' "$f")
+              SUCCESS=$(jq -r '.successful' "$f")
+
+              JOB_NAME="Build $NAME"
+              JOB_URL=$(jq -r --arg key "$JOB_NAME" '.[$key] // empty' job_urls.json)
+              if [ -z "$JOB_URL" ]; then
+                JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              fi
+
+              if [ "$SUCCESS" = "true" ]; then
+                STATUS="[Success]($JOB_URL)"
+              else
+                STATUS="[Failed]($JOB_URL)"
+              fi
+
+              echo "| \`$NAME\` | $STATUS | \`$DRV\` |"
+            done
+          } > summary_report.md
+
+          cat summary_report.md >> $GITHUB_STEP_SUMMARY
+
+          if grep -q '"successful": false' report_*.json 2>/dev/null; then
+            echo "Error: Some packages failed to build." >&2
+            exit 1
+          fi

--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779907315,
-        "narHash": "sha256-kO1yw+iTIENBQVDCm2+NDtWSUIkUADPgtFdumxcblqM=",
+        "lastModified": 1779995108,
+        "narHash": "sha256-Q7+brnNu0W/ael1fwaIhxqhf2BfxzLWmaA+Ad/v+ueI=",
         "owner": "lonerOrz",
         "repo": "nyx-loner",
-        "rev": "16551efe331001bbf90de25f087990ce74a2c95c",
+        "rev": "955e036fa6d52148d3571226bc8723bfb884991b",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1779969295,
+        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779787240,
-        "narHash": "sha256-hqpzAmYzcKvo+i0XCDgDCAV9WzW1a7gzQWGjp8Dfcjg=",
+        "lastModified": 1779910845,
+        "narHash": "sha256-K+ugPxAsjCT4soO3vadlKs7MKIfH3WqB5Z4xt/jeWyU=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "976bb49bfc30f716c1e94cef55845e915631a4c6",
+        "rev": "3565a61af78debd93ae92a121a6f4683c952d862",
         "type": "github"
       },
       "original": {
@@ -1239,11 +1239,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779786838,
-        "narHash": "sha256-0geHoGiR5f8qiXg+gO4rSF6Up6Var+kKqiOv9AO/uUc=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f44f7788c891fbe5542177df78374f8cdab10e8f",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1779992660,
-        "narHash": "sha256-QIu5/Mm1g2UBWVmtQUvpfa/Y+4nfZetCaahBlvnBrsM=",
+        "lastModified": 1780006453,
+        "narHash": "sha256-BiJI3QO1LoI3ljjFmOS3+gyPrZs8tilxYMo/1QhNDCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6910da5125529fa930d4ef43425309f8266ca7ae",
+        "rev": "51d08e9395c2bd7d9732beb4427a93acd6abd165",
         "type": "github"
       },
       "original": {
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779991050,
-        "narHash": "sha256-s+aDfDJVdg9JA0HPZ3Wil1UVkxL/Y1OsnYtsYjf+U14=",
+        "lastModified": 1780006782,
+        "narHash": "sha256-X4XiUG3Ntzhu6CUtl8duc2v7+zqS/pPQUix2nmmH2UU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6693686693d842842a699ffad11dc2ab35597ab2",
+        "rev": "279110e59836b103e5b63e421c147412b864ec21",
         "type": "github"
       },
       "original": {
@@ -1749,11 +1749,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779851998,
-        "narHash": "sha256-UkkMh3bX9QW4Luqkm98nUaOqKWrU6i65mUnph3WeSSw=",
+        "lastModified": 1779992051,
+        "narHash": "sha256-4YWGv/0NkAdtTW1MXfaLYpfC9BhpCy9k1pWkR0xI9uw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6cddd512fa2bf7231f098d3a2f92f6e4cff71e0a",
+        "rev": "e93ad0df1073b2c969a8f0c1f10b84e870469d40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Flake Inputs Update
🔄 Updating 30 inputs (excluding: lix-module, lix)

✨ Update details:
- chaotic: blqM%3D → BueI%3D
- chaotic/home-manager: cQqA%3D → cTnA%3D
- chaotic/jovian: fcjg%3D → eWyU%3D
- chaotic/nixpkgs: uUc%3D → yARk%3D
- chaotic/rust-overlay: eSSw%3D → I9uw%3D
- nixpkgs-master: BrsM%3D → NDCg%3D
- nur: BU14%3D → H2UU%3D
